### PR TITLE
Fix the link of "Edit this page"

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -78,15 +78,13 @@ module.exports = {
                     // It is recommended to set document id as docs home page (`docs/` path).
                     homePageId: 'compile',
                     sidebarPath: require.resolve('./sidebars.js'),
-                    // Please change this to your repo.
                     editUrl:
-                        'https://github.com/facebook/docusaurus/edit/master/website/',
+                        'https://github.com/cylondata/cylon/edit/master/docs/',
                 },
                 blog: {
                     showReadingTime: true,
-                    // Please change this to your repo.
                     editUrl:
-                        'https://github.com/facebook/docusaurus/edit/master/website/blog/',
+                        'https://github.com/cylondata/cylon/edit/master/blog/',
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/1425259/99100247-938b1b00-25a9-11eb-92c2-f3feaac26c27.png)

Currently, the button to edit the page is broken, which links to the Facebook repository. For example, see https://cylondata.org/docs/#example. This PR fixes the link and allows users to create PR of the docs easily.