### PR TITLE
Fix the markdown and refine syntax

### DIFF
--- a/docs/docs/cpp.md
+++ b/docs/docs/cpp.md
@@ -95,21 +95,25 @@ Distributed initialization
 ## `cylon::Table` 
 
 ### Reading tables 
+
 A `cylon::Table` can be created from a csv file as follows. 
+
 ```cpp
 std::shared_ptr<cylon::Table> table1;
 auto read_options = CSVReadOptions();
 auto status = cylon::FromCSV(ctx, "/path/to/csv", table1, read_options))
 ```
 
-Read a set of tables using threads, 
+Read a set of tables using threads,
+
 ```cpp
 std::shared_ptr<cylon::Table> table1, table2;
 auto read_options = CSVReadOptions().UseThreads(true);
 auto status = cylon::FromCSV(ctx, {"/path/to/csv1.csv", "/path/to/csv2.csv"}, {table1, table2}, read_options);
 ```
 
-An `arrow::Table` can be imported as follows, 
+An `arrow::Table` can be imported as follows,
+
 ```cpp
 std::shared_ptr<cylon::Table> table1;
 std::shared_ptr<arrow::Table> some_arrow_table = ...;
@@ -117,7 +121,9 @@ auto status = cylon::Table::FromArrowTable(ctx, some_arrow_table, table1);
 ```
 
 ### Writing tables 
+
 A `cylon::Table` can be written to a CSV file as follows, 
+
 ```cpp
 std::shared_ptr<cylon::Table> table1; 
 ...
@@ -126,6 +132,7 @@ auto status = table1->WriteCSV("/path/to/csv", write_options);
 ```
 
 A `cylon::Table` can be coverted into an `arrow::Table` by simply, 
+
 ```cpp
 std::shared_ptr<arrow::Table> some_arrow_table;
 std::shared_ptr<cylon::Table> table1; 

--- a/docs/docs/mpi.md
+++ b/docs/docs/mpi.md
@@ -10,6 +10,7 @@ Cylon executables can be run with MPI distributions as follows.
 To run the `cpp/src/examples/join_example.cpp`, first compile cylon. 
 
 Then, run the executable,
+
 ```bash
 mpirun -np <NUM_WORKERS> <CYLON_HOME>/bin/join_example /path/to/csv1 /path/to/csv2
 ```
@@ -17,6 +18,7 @@ mpirun -np <NUM_WORKERS> <CYLON_HOME>/bin/join_example /path/to/csv1 /path/to/cs
 ## Python 
 
 To run the `python/test/test_dist_rl.py`, 
+
 ```bash
 mpirun -np <NUM_WORKERS> <PYTHON_ENV>/bin/python3 <CYLON_HOME>/python/test/test_dist_rl.py
 ```
@@ -25,11 +27,13 @@ mpirun -np <NUM_WORKERS> <PYTHON_ENV>/bin/python3 <CYLON_HOME>/python/test/test_
 
 To run the `java/src/main/java/org/cylondata/cylon/examples/DistributedJoinExample.java`, first create a 
 fat-jar with the executables
+
 ```bash
 mvn clean package
 ``` 
 
 Then run the fat-jar main class,
+
 ```bash
 mpirun -np <NUM_WORKERS> java -cp <CYLON_HOME>/target/cylon-0.1.0-jar-with-dependencies.jar  org.cylondata.cylon.examples.DistributedJoinExample /path/to/csv1 /path/to/csv2
 ```

--- a/docs/docs/python.md
+++ b/docs/docs/python.md
@@ -60,6 +60,7 @@ Also a Cylon Table can be converted to a PyArrow Table
 ```python
 pyarrow_tb: PyArrowTable = cylon_tb.to_arrow()
 ```
+
 ### Join
 
 Join API supports `left, right, inner, outer' joins` with
@@ -143,7 +144,5 @@ This is not yet supported from PyCylon API, but LibCylon supports this.
 
 ## Python Examples
 
-1. [Relational Algebra Examples](https://github.com/cylondata/cylon/blob/master/python/examples
-/table_relational_algebra.py)
-2. [Compute Examples](https://github.com/cylondata/cylon/blob/master/python/examples
-/table_compute_examples.py)
+1. [Relational Algebra Examples](https://github.com/cylondata/cylon/blob/master/python/examples/table_relational_algebra.py)
+2. [Compute Examples](https://github.com/cylondata/cylon/blob/master/python/examples/table_compute_examples.py)


### PR DESCRIPTION
This PR fixes broken links in the Python page and refine markdown syntax on several pages by inserting newlines.

**Broken links**

https://cylondata.org/docs/python

![](https://user-images.githubusercontent.com/1425259/99104547-1f537600-25af-11eb-8873-a8eba9e15dd6.png)