### PR TITLE
fix #340 

### DIFF
--- a/cpp/src/cylon/groupby/hash_groupby.cpp
+++ b/cpp/src/cylon/groupby/hash_groupby.cpp
@@ -264,7 +264,7 @@ Status HashGroupBy(const std::shared_ptr<Table> &table,
   auto t2 = std::chrono::steady_clock::now();
 
   std::vector<int64_t> group_ids;
-  int64_t unique_groups;
+  int64_t unique_groups = 0;
   std::shared_ptr<arrow::Array> group_filter;
   RETURN_CYLON_STATUS_IF_FAILED(make_groups(pool, atable, idx_cols, group_ids, group_filter, &unique_groups))
 

--- a/cpp/src/cylon/util/macros.hpp
+++ b/cpp/src/cylon/util/macros.hpp
@@ -19,25 +19,37 @@
   LOG(ERROR) << msg ; \
   return cylon::Status(code, msg);
 
-#define RETURN_CYLON_STATUS_IF_FAILED(status) \
-  if (!status.is_ok()) { \
-    return status; \
-  };
+#define RETURN_CYLON_STATUS_IF_FAILED(expr) \
+  do{                                       \
+    const auto& _st = (expr);               \
+    if (!_st.is_ok()) {                     \
+      return _st;                           \
+    };                                      \
+  } while (0);
 
-#define LOG_AND_RETURN_CYLON_STATUS_IF_FAILED(status) \
-  if (!status.is_ok()) { \
-    LOG(ERROR) << status.get_msg() ; \
-    return status; \
-  };
+#define LOG_AND_RETURN_CYLON_STATUS_IF_FAILED(expr) \
+  do{                               \
+    const auto& _st = (expr);       \
+    if (!_st.is_ok()) {             \
+      LOG(ERROR) << _st.get_msg() ; \
+      return _st;                   \
+    };                              \
+  } while (0);
 
-#define RETURN_CYLON_STATUS_IF_ARROW_FAILED(status) \
-  if (!status.ok()) { \
-    return cylon::Status(static_cast<int>(status.code()), status.message()); \
-  };
+#define RETURN_CYLON_STATUS_IF_ARROW_FAILED(expr) \
+  do{                               \
+    const auto& _st = (expr);       \
+    if (!_st.ok()) { \
+      return cylon::Status(static_cast<int>(_st.code()), _st.message()); \
+    };                              \
+  } while (0);
 
-#define RETURN_ARROW_STATUS_IF_FAILED(status) \
-  if (!status.ok()) { \
-    return status; \
-  };
+#define RETURN_ARROW_STATUS_IF_FAILED(expr) \
+  do{                               \
+    const auto& _st = (expr);       \
+    if (!_st.ok()) {                \
+      return _st;                   \
+    };                              \
+  } while (0);
 
 #endif //CYLON_CPP_SRC_CYLON_UTIL_MACROS_HPP_


### PR DESCRIPTION
fix #340 Using of macros in macros.hpp evaluates an object twice (if status failed) 