### PR TITLE
made all-to-all buffers const

### DIFF
--- a/cpp/src/cylon/arrow/arrow_all_to_all.cpp
+++ b/cpp/src/cylon/arrow/arrow_all_to_all.cpp
@@ -230,7 +230,7 @@ bool ArrowAllToAll::onReceiveHeader(int source, int fin, int *buffer, int length
   return true;
 }
 
-bool ArrowAllToAll::onSendComplete(int target, void *buffer, int length) {
+bool ArrowAllToAll::onSendComplete(int target, const void *buffer, int length) {
 //    pool_->Free((uint8_t *)buffer, length);
   return false;
 }

--- a/cpp/src/cylon/arrow/arrow_all_to_all.hpp
+++ b/cpp/src/cylon/arrow/arrow_all_to_all.hpp
@@ -183,7 +183,7 @@ class ArrowAllToAll : public ReceiveCallback {
    */
   bool onReceiveHeader(int source, int finished, int *buffer, int length) override;
 
-  bool onSendComplete(int target, void *buffer, int length) override;
+  bool onSendComplete(int target, const void *buffer, int length) override;
 
  private:
   /**

--- a/cpp/src/cylon/code.cpp
+++ b/cpp/src/cylon/code.cpp
@@ -28,6 +28,7 @@ enum Code {
   UnknownError = 9,
   NotImplemented = 10,
   SerializationError = 11,
+  GpuMemoryError = 12,
   RError = 13,
   // Gandiva range of errors
   CodeGenError = 40,

--- a/cpp/src/cylon/net/TxRequest.cpp
+++ b/cpp/src/cylon/net/TxRequest.cpp
@@ -24,13 +24,13 @@ cylon::TxRequest::TxRequest(int tgt) {
   target = tgt;
 }
 
-cylon::TxRequest::TxRequest(int tgt, void *buf, int len) {
+cylon::TxRequest::TxRequest(int tgt, const void *buf, int len) {
   target = tgt;
   buffer = buf;
   length = len;
 }
 
-cylon::TxRequest::TxRequest(int tgt, void *buf, int len, int *head, int hLength) {
+cylon::TxRequest::TxRequest(int tgt, const void *buf, int len, int *head, int hLength) {
   target = tgt;
   buffer = buf;
   length = len;

--- a/cpp/src/cylon/net/TxRequest.hpp
+++ b/cpp/src/cylon/net/TxRequest.hpp
@@ -21,15 +21,15 @@ namespace cylon {
 class TxRequest {
 
  public:
-  void *buffer{};
+  const void *buffer{};
   int length{};
   int target;
   int header[6] = {};
   int headerLength{};
 
-  TxRequest(int tgt, void *buf, int len);
+  TxRequest(int tgt, const void *buf, int len);
 
-  TxRequest(int tgt, void *buf, int len, int *head, int hLength);
+  TxRequest(int tgt, const void *buf, int len, int *head, int hLength);
 
   explicit TxRequest(int tgt);
 

--- a/cpp/src/cylon/net/ops/all_to_all.cpp
+++ b/cpp/src/cylon/net/ops/all_to_all.cpp
@@ -61,7 +61,7 @@ void AllToAll::close() {
   delete channel;
 }
 
-int AllToAll::insert(void *buffer, int length, int target) {
+int AllToAll::insert(const void *buffer, int length, int target) {
   if (finishFlag) {
 	// we cannot accept further
 	return -1;
@@ -75,7 +75,7 @@ int AllToAll::insert(void *buffer, int length, int target) {
   return 1;
 }
 
-int AllToAll::insert(void *buffer, int length, int target, int *header, int headerLength) {
+int AllToAll::insert(const void *buffer, int length, int target, int *header, int headerLength) {
   if (finishFlag) {
 	// we cannot accept further
 	return -1;

--- a/cpp/src/cylon/net/ops/all_to_all.hpp
+++ b/cpp/src/cylon/net/ops/all_to_all.hpp
@@ -53,7 +53,7 @@ class ReceiveCallback {
    * @param length
    * @return
    */
-  virtual bool onSendComplete(int target, void *buffer, int length) = 0;
+  virtual bool onSendComplete(int target, const void *buffer, int length) = 0;
 };
 
 enum AllToAllSendStatus {
@@ -98,7 +98,7 @@ class AllToAll : public ChannelReceiveCallback, ChannelSendCallback {
    * @param target the target to send the message
    * @return true if the buffer is accepted
    */
-  int insert(void *buffer, int length, int target, int *header, int headerLength);
+  int insert(const void *buffer, int length, int target, int *header, int headerLength);
 
   /**
    * Insert a buffer to be sent, if the buffer is accepted return true
@@ -108,7 +108,7 @@ class AllToAll : public ChannelReceiveCallback, ChannelSendCallback {
    * @param target the target to send the message
    * @return true if the buffer is accepted
    */
-  int insert(void *buffer, int length, int target);
+  int insert(const void *buffer, int length, int target);
 
   /**
    * Check weather the operation is complete, this method needs to be called until the operation is complete

--- a/cpp/src/cylon/util/builtins.cpp
+++ b/cpp/src/cylon/util/builtins.cpp
@@ -16,76 +16,76 @@
 #include <string>
 #include <iostream>
 
-void cylon::util::printArray(void *buf, int size, std::string dataType, int depth) {
+void cylon::util::printArray(const void *buf, int size, std::string dataType, int depth) {
   if (dataType == "int") {
     if (depth == 8) {
-      int8_t *int8Ptr = reinterpret_cast<int8_t *>(buf);  // getIntPointer<8>(buf);
+      const int8_t *int8Ptr = reinterpret_cast<const int8_t *>(buf);  // getIntPointer<8>(buf);
       printInt8Array(int8Ptr, size);
     } else if (depth == 16) {
-      int16_t *int16Ptr = reinterpret_cast<int16_t *>(buf);  // getIntPointer<16>(buf);
+      const int16_t *int16Ptr = reinterpret_cast<const int16_t *>(buf);  // getIntPointer<16>(buf);
       printInt16Array(int16Ptr, size);
     } else if (depth == 32) {
-      int32_t *int32Ptr = reinterpret_cast<int32_t *>(buf);  // getIntPointer<32>(buf);
+      const int32_t *int32Ptr = reinterpret_cast<const int32_t *>(buf);  // getIntPointer<32>(buf);
       printInt32Array(int32Ptr, size);
     } else if (depth == 64) {
-      int64_t *int64Ptr = reinterpret_cast<int64_t *>(buf);  // getIntPointer<64>(buf);
+      const int64_t *int64Ptr = reinterpret_cast<const int64_t *>(buf);  // getIntPointer<64>(buf);
       printInt64Array(int64Ptr, size);
     }
   } else if (dataType == "float") {
-    float *floatPtr = reinterpret_cast<float *>(buf);  // getFloatPointer(buf);
+    const float *floatPtr = reinterpret_cast<const float *>(buf);  // getFloatPointer(buf);
     printFloatArray(floatPtr, size);
   } else if (dataType == "double") {
-    double *doublePtr = reinterpret_cast<double *>(buf);  // getFloatPointer(buf);
+    const double *doublePtr = reinterpret_cast<const double *>(buf);  // getFloatPointer(buf);
     printDoubleArray(doublePtr, size);
   } else if (dataType == "long") {
-    int64_t *longPtr = reinterpret_cast<int64_t *>(buf);  // getFloatPointer(buf);
+    const int64_t *longPtr = reinterpret_cast<const int64_t *>(buf);  // getFloatPointer(buf);
     printLongArray(longPtr, size);
   }
 }
 
-void cylon::util::printInt8Array(int8_t *buf, int size) {
+void cylon::util::printInt8Array(const int8_t *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void cylon::util::printInt16Array(int16_t *buf, int size) {
+void cylon::util::printInt16Array(const int16_t *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void cylon::util::printInt32Array(int32_t *buf, int size) {
+void cylon::util::printInt32Array(const int32_t *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void cylon::util::printInt64Array(int64_t *buf, int size) {
+void cylon::util::printInt64Array(const int64_t *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void cylon::util::printFloatArray(float *buf, int size) {
+void cylon::util::printFloatArray(const float *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void cylon::util::printDoubleArray(double *buf, int size) {
+void cylon::util::printDoubleArray(const double *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void cylon::util::printLongArray(int64_t *buf, int size) {
+void cylon::util::printLongArray(const int64_t *buf, int size) {
   for (int i = 0; i < size; ++i) {
     std::cout << buf[i] << " ";
   }

--- a/cpp/src/cylon/util/builtins.hpp
+++ b/cpp/src/cylon/util/builtins.hpp
@@ -21,21 +21,21 @@
 namespace cylon {
 namespace util {
 
-void printArray(void *buf, int size, std::string dataType, int depth);
+void printArray(const void *buf, int size, std::string dataType, int depth);
 
-void printInt8Array(int8_t *buf, int size);
+void printInt8Array(const int8_t *buf, int size);
 
-void printInt16Array(int16_t *buf, int size);
+void printInt16Array(const int16_t *buf, int size);
 
-void printInt32Array(int32_t *buf, int size);
+void printInt32Array(const int32_t *buf, int size);
 
-void printInt64Array(int64_t *buf, int size);
+void printInt64Array(const int64_t *buf, int size);
 
-void printFloatArray(float *buf, int size);
+void printFloatArray(const float *buf, int size);
 
-void printDoubleArray(double *buf, int size);
+void printDoubleArray(const double *buf, int size);
 
-void printLongArray(int64_t *buf, int size);
+void printLongArray(const int64_t *buf, int size);
 }  // namespace util
 }  // namespace cylon
 


### PR DESCRIPTION
needed to make the buffers of the insert methods of all-to-all class const, since cudf table returns const buffers.