### PR TITLE
Minor improvements to the Table API

### DIFF
--- a/cpp/src/cylon/CMakeLists.txt
+++ b/cpp/src/cylon/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(cylon SHARED
         arrow/arrow_partition_kernels.hpp
         arrow/arrow_task_all_to_all.cpp
         arrow/arrow_task_all_to_all.h
+        arrow/arrow_type_traits.hpp
         arrow/arrow_types.cpp
         arrow/arrow_types.hpp
         column.cpp

--- a/cpp/src/cylon/arrow/arrow_all_to_all.cpp
+++ b/cpp/src/cylon/arrow/arrow_all_to_all.cpp
@@ -20,6 +20,7 @@
 
 #include <cylon/arrow/arrow_all_to_all.hpp>
 #include <cylon/ctx/arrow_memory_pool_utils.hpp>
+#include <cylon/util/macros.hpp>
 
 namespace cylon {
 ArrowAllToAll::ArrowAllToAll(const std::shared_ptr<cylon::CylonContext> &ctx,
@@ -171,6 +172,7 @@ void ArrowAllToAll::close() {
 }*/
 
 bool ArrowAllToAll::onReceive(int source, std::shared_ptr<Buffer> buffer, int length) {
+  CYLON_UNUSED(length);
   std::shared_ptr<PendingReceiveTable> table = receives_[source];
   receivedBuffers_++;
   // create the buffer hosting the value
@@ -233,6 +235,9 @@ bool ArrowAllToAll::onReceiveHeader(int source, int fin, int *buffer, int length
 
 bool ArrowAllToAll::onSendComplete(int target, const void *buffer, int length) {
 //    pool_->Free((uint8_t *)buffer, length);
+  CYLON_UNUSED(target);
+  CYLON_UNUSED(buffer);
+  CYLON_UNUSED(length);
   return false;
 }
 

--- a/cpp/src/cylon/arrow/arrow_all_to_all.hpp
+++ b/cpp/src/cylon/arrow/arrow_all_to_all.hpp
@@ -106,7 +106,7 @@ using ArrowCallback = std::function<bool(int source, const std::shared_ptr<arrow
 class ArrowAllocator : public Allocator {
  public:
   explicit ArrowAllocator(arrow::MemoryPool *pool);
-  virtual ~ArrowAllocator();
+  ~ArrowAllocator() override;
 
   Status Allocate(int64_t length, std::shared_ptr<Buffer> *buffer) override;
  private:

--- a/cpp/src/cylon/arrow/arrow_comparator.cpp
+++ b/cpp/src/cylon/arrow/arrow_comparator.cpp
@@ -251,7 +251,7 @@ class TwoBinaryRowIndexComparator : public TwoArrayIndexComparator {
   using ARROW_ARRAY_T = typename arrow::TypeTraits<TYPE>::ArrayType;
  public:
   explicit TwoBinaryRowIndexComparator(const std::shared_ptr<arrow::Array> &a1, const std::shared_ptr<arrow::Array> &a2)
-      : arrays({std::static_pointer_cast<ARROW_ARRAY_T>(a1), std::static_pointer_cast<ARROW_ARRAY_T>(a1)}) {}
+      : arrays({std::static_pointer_cast<ARROW_ARRAY_T>(a1), std::static_pointer_cast<ARROW_ARRAY_T>(a2)}) {}
 
   int compare(int64_t index1, int64_t index2) const override {
     if (ASC) {

--- a/cpp/src/cylon/arrow/arrow_comparator.cpp
+++ b/cpp/src/cylon/arrow/arrow_comparator.cpp
@@ -16,6 +16,7 @@
 #include <cylon/util/arrow_utils.hpp>
 
 #include <glog/logging.h>
+#include <cylon/util/macros.hpp>
 
 namespace cylon {
 
@@ -157,9 +158,17 @@ class EmptyIndexComparator : public ArrayIndexComparator {
  public:
   explicit EmptyIndexComparator() = default;
 
-  int compare(int64_t index1, int64_t index2) const override { return 0; }
+  int compare(int64_t index1, int64_t index2) const override {
+    CYLON_UNUSED(index1);
+    CYLON_UNUSED(index2);
+    return 0;
+  }
 
-  bool equal_to(const int64_t index1, const int64_t index2) const override { return true; }
+  bool equal_to(const int64_t index1, const int64_t index2) const override {
+    CYLON_UNUSED(index1);
+    CYLON_UNUSED(index2);
+    return true;
+  }
 };
 
 template<bool ASC>
@@ -334,9 +343,7 @@ std::shared_ptr<TwoArrayIndexComparator> CreateTwoArrayIndexComparator(const std
   }
 }
 
-RowEqualTo::RowEqualTo(std::shared_ptr<cylon::CylonContext> &ctx,
-                       const std::shared_ptr<arrow::Table> *tables, int64_t *eq,
-                       int64_t *hs) {
+RowEqualTo::RowEqualTo(const std::shared_ptr<arrow::Table> *tables, int64_t *eq, int64_t *hs) {
   this->tables = tables;
   this->comparator = std::make_shared<cylon::TableRowComparator>(tables[0]->fields());
   this->row_hashing_kernel = std::make_shared<cylon::RowHashingKernel>(tables[0]->fields());

--- a/cpp/src/cylon/arrow/arrow_comparator.hpp
+++ b/cpp/src/cylon/arrow/arrow_comparator.hpp
@@ -132,8 +132,7 @@ std::shared_ptr<TwoArrayIndexComparator> CreateTwoArrayIndexComparator(const std
  */
 class RowEqualTo {
  public:
-  RowEqualTo(std::shared_ptr<cylon::CylonContext> &ctx, const std::shared_ptr<arrow::Table> *tables,
-             int64_t *eq, int64_t *hs);
+  RowEqualTo(const std::shared_ptr<arrow::Table> *tables, int64_t *eq, int64_t *hs);
 
   // equality
   bool operator()(const std::pair<int8_t, int64_t> &record1, const std::pair<int8_t, int64_t> &record2) const;

--- a/cpp/src/cylon/arrow/arrow_kernels.cpp
+++ b/cpp/src/cylon/arrow/arrow_kernels.cpp
@@ -236,13 +236,13 @@ class ArrowBinarySortKernel : public IndexSortKernel {
     auto array = std::static_pointer_cast<ARRAY_T>(values);
 
     if (ascending) {
-      return DoSort(
+      return do_sort(
           [&array](uint64_t left, uint64_t right) {
             return array->GetView(left).compare(array->GetView(right)) < 0;
           },
           values->length(), pool_, offsets);
     } else {
-      return DoSort(
+      return do_sort(
           [&array](uint64_t left, uint64_t right) {
             return array->GetView(left).compare(array->GetView(right)) > 0;
           },
@@ -268,13 +268,13 @@ class NumericIndexSortKernel : public IndexSortKernel {
     const T *left_data = array->raw_values();
 
     if (ascending) {
-      return DoSort([&left_data](uint64_t left,
-                                 uint64_t right) { return left_data[left] < left_data[right]; },
-                    values->length(), pool_, offsets);
+      return do_sort([&left_data](uint64_t left,
+                                  uint64_t right) { return left_data[left] < left_data[right]; },
+                     values->length(), pool_, offsets);
     } else {
-      return DoSort([&left_data](uint64_t left,
-                                 uint64_t right) { return left_data[left] > left_data[right]; },
-                    values->length(), pool_, offsets);
+      return do_sort([&left_data](uint64_t left,
+                                  uint64_t right) { return left_data[left] > left_data[right]; },
+                     values->length(), pool_, offsets);
     }
   }
 };
@@ -410,18 +410,14 @@ arrow::Status SortIndicesInPlace(arrow::MemoryPool *memory_pool,
   return out->Sort(values, offsets);
 }
 
-arrow::Status IndexSortKernel::DoSort(const std::function<bool(int64_t, int64_t)> &comp,
-                                      int64_t len, arrow::MemoryPool *pool,
-                                      std::shared_ptr<arrow::UInt64Array> &offsets) {
-  int64_t buf_size = len * sizeof(int64_t);
+template<typename Comparator>
+arrow::Status do_sort(Comparator &&comp, int64_t len, arrow::MemoryPool *pool,
+                      std::shared_ptr<arrow::UInt64Array> &offsets) {
+  auto buf_size = static_cast<int64_t>(len * sizeof(int64_t));
 
-  arrow::Result<std::unique_ptr<arrow::Buffer>> result = arrow::AllocateBuffer(buf_size + 1, pool);
-  const arrow::Status &status = result.status();
-  if (!status.ok()) {
-    LOG(FATAL) << "Failed to allocate sort indices - " << status.message();
-    return status;
-  }
-  std::shared_ptr<arrow::Buffer> indices_buf(std::move(result.ValueOrDie()));
+  arrow::Result<std::unique_ptr<arrow::Buffer>> result = arrow::AllocateBuffer(buf_size, pool);
+  RETURN_ARROW_STATUS_IF_FAILED(result.status());
+  std::shared_ptr<arrow::Buffer> indices_buf(std::move(result).ValueOrDie());
 
   auto *indices_begin = reinterpret_cast<int64_t *>(indices_buf->mutable_data());
   for (int64_t i = 0; i < len; i++) {

--- a/cpp/src/cylon/arrow/arrow_kernels.hpp
+++ b/cpp/src/cylon/arrow/arrow_kernels.hpp
@@ -68,19 +68,6 @@ class IndexSortKernel {
 
   virtual ~IndexSortKernel() = default;
 
- protected:
-  /**
-   * Runs the sorting operation based on the comparator lambda
-   * @param comp
-   * @param len
-   * @param pool
-   * @param offsets
-   * @return
-   */
-  static arrow::Status DoSort(const std::function<bool(int64_t, int64_t)> &comp, int64_t len,
-                              arrow::MemoryPool *pool,
-                              std::shared_ptr<arrow::UInt64Array> &offsets);
-
   arrow::MemoryPool *pool_;
   bool ascending;
 };

--- a/cpp/src/cylon/arrow/arrow_partition_kernels.cpp
+++ b/cpp/src/cylon/arrow/arrow_partition_kernels.cpp
@@ -14,6 +14,8 @@
 
 #include <glog/logging.h>
 
+#include <arrow/visitor_inline.h>
+
 #include <cylon/util/murmur3.hpp>
 #include <cylon/util/macros.hpp>
 #include <cylon/util/arrow_utils.hpp>
@@ -21,6 +23,7 @@
 #include <cylon/net/mpi/mpi_operations.hpp>
 #include <cylon/arrow/arrow_partition_kernels.hpp>
 #include <cylon/arrow/arrow_types.hpp>
+#include "cylon/arrow/arrow_type_traits.hpp"
 
 namespace cylon {
 
@@ -29,35 +32,42 @@ static inline constexpr bool if_power2(T v) {
   return v && !(v & (v - 1));
 }
 
-template<typename ARROW_ARRAY_T>
-using LoopRunner = std::function<void(const std::shared_ptr<ARROW_ARRAY_T> &casted_arr,
-                                      uint64_t global_idx,
-                                      uint64_t idx)>;
-
-template<typename ARROW_ARRAY_T>
-static inline void run_loop(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
-                            const LoopRunner<ARROW_ARRAY_T> &runner) {
-  uint64_t offset = 0;
-  for (const auto &arr: idx_col->chunks()) {
-    const std::shared_ptr<ARROW_ARRAY_T> &carr = std::static_pointer_cast<ARROW_ARRAY_T>(arr);
-    for (int64_t i = 0; i < carr->length(); i++, offset++) {
-      runner(carr, offset, i);
-    }
-  }
+template<typename T>
+static inline constexpr uint32_t mod_power2(T val, uint32_t num_partitions) {
+  return val & (num_partitions - 1);
 }
 
-using Partitioner = std::function<uint32_t(uint64_t)>;
+template<typename T>
+static inline constexpr uint32_t mod(T val, uint32_t num_partitions) {
+  return val % num_partitions;
+}
 
-static inline Partitioner get_partitioner(uint32_t num_partitions) {
-  if (if_power2(num_partitions)) {
-    return [num_partitions](uint32_t val) {
-      return val & (num_partitions - 1);
-    };
-  } else {
-    return [num_partitions](uint32_t val) {
-      return val % num_partitions;
-    };
+template<typename ArrowT, typename Visitor>
+inline Status visit_chunked_array(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
+                                  Visitor &&visitor) {
+  using ValueT = typename cylon::ArrowTypeTraits<ArrowT>::ValueT;
+
+  uint64_t global_idx = 0;
+  for (auto &&array: idx_col->chunks()) {
+    const auto &arr_data = array->data();
+    if (array->null_count()) {
+      return {Code::NotImplemented, "nulls in index arrays are not supported!"};
+    }
+
+    arrow::VisitArrayDataInline<ArrowT>(*arr_data,
+                                        [&](ValueT val) {
+                                          visitor(global_idx, val);
+                                          global_idx++;
+                                        },
+                                        [&]() { // nothing to do for nulls
+                                          global_idx++;
+                                        }
+    );
   }
+  // global index should match the chunk array length
+  assert(idx_col->length() == static_cast<int64_t>(global_idx));
+
+  return Status::OK();
 }
 
 template<typename ARROW_T, typename = typename std::enable_if<
@@ -65,56 +75,55 @@ template<typename ARROW_T, typename = typename std::enable_if<
         | arrow::is_boolean_type<ARROW_T>::value
         | arrow::is_temporal_type<ARROW_T>::value>::type>
 class ModuloPartitionKernel : public HashPartitionKernel {
-  using ARROW_ARRAY_T = typename arrow::TypeTraits<ARROW_T>::ArrayType;
-  using T = typename ARROW_T::c_type;
-public:
+  using ArrayT = typename arrow::TypeTraits<ARROW_T>::ArrayType;
+  using T = typename cylon::ArrowTypeTraits<ARROW_T>::ValueT;
+ public:
   Status Partition(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
                    uint32_t num_partitions,
                    std::vector<uint32_t> &target_partitions,
                    std::vector<uint32_t> &partition_histogram) override {
     if (partition_histogram.size() != num_partitions
         || target_partitions.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "target partitions or histogram not initialized!");
+      return {Code::Invalid, "target partitions or histogram not initialized!"};
     }
 
-    Partitioner partitioner = get_partitioner(num_partitions);
-    uint64_t offset = 0;
-    for (const auto &arr: idx_col->chunks()) {
-      const std::shared_ptr<arrow::ArrayData> &data = arr->data();
-      T *value_buffer = data->template GetMutableValues<T>(1);
-
-      int64_t length = arr->length();
-      for (int64_t i = 0; i < length; i++, offset++) {
-        uint32_t pseudo_hash = 31 * target_partitions[offset] + static_cast<uint32_t>(value_buffer[i]);
-        uint32_t p = pseudo_hash % num_partitions;
-        target_partitions[offset] = p;
-        partition_histogram[p]++;
-      }
+    if (if_power2(num_partitions)) {
+      return visit_chunked_array<ARROW_T>(
+          idx_col,
+          [&](uint64_t offset, T val) {
+            T pseudo_hash = 31 * target_partitions[offset] + val;
+            uint32_t p = mod_power2(pseudo_hash, num_partitions);
+            target_partitions[offset] = p;
+            partition_histogram[p]++;
+          });
+    } else {
+      return visit_chunked_array<ARROW_T>(
+          idx_col,
+          [&](uint64_t offset, T val) {
+            T pseudo_hash = 31 * target_partitions[offset] + val;
+            uint32_t p = mod(pseudo_hash, num_partitions);
+            target_partitions[offset] = p;
+            partition_histogram[p]++;
+          });
     }
-    return Status::OK();
   }
 
   Status UpdateHash(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
                     std::vector<uint32_t> &partial_hashes) override {
     if (partial_hashes.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "partial hashes size != idx col length!");
+      return {Code::Invalid, "partial hashes size != idx col length!"};
     }
 
-    uint64_t offset = 0;
-    for (const auto &arr: idx_col->chunks()) {
-      const std::shared_ptr<arrow::ArrayData> &data = arr->data();
-      const T *value_buffer = data->template GetValues<T>(1);
-      int64_t length = arr->length();
-      for (int64_t i = 0; i < length; i++, offset++) {
-        partial_hashes[offset] = 31 * partial_hashes[offset] + static_cast<uint32_t>(value_buffer[i]);
-      }
-    }
-
-    return Status::OK();
+    return visit_chunked_array<ARROW_T>(
+        idx_col,
+        [&](uint64_t offset, T val) {
+          partial_hashes[offset] = 31 * partial_hashes[offset] + val;
+        });
   }
 
-  inline uint32_t ToHash(const std::shared_ptr<arrow::Array> &values, int64_t index) override {
-    const std::shared_ptr<ARROW_ARRAY_T> &carr = std::static_pointer_cast<ARROW_ARRAY_T>(values);
+  inline uint32_t ToHash(const std::shared_ptr<arrow::Array> &values, int64_t index)
+  override {
+    const auto &carr = std::static_pointer_cast<ArrayT>(values);
     return static_cast<uint32_t>(carr->Value(index));
   }
 };
@@ -122,8 +131,8 @@ public:
 template<typename ARROW_T, typename = typename std::enable_if<
     arrow::is_number_type<ARROW_T>::value | arrow::is_boolean_type<ARROW_T>::value>::type>
 class NumericHashPartitionKernel : public HashPartitionKernel {
-  using ARROW_ARRAY_T = typename arrow::TypeTraits<ARROW_T>::ArrayType;
-  using ARROW_CTYPE = typename arrow::TypeTraits<ARROW_T>::CType;
+  using ArrayT = typename arrow::TypeTraits<ARROW_T>::ArrayType;
+  using ValueT = typename cylon::ArrowTypeTraits<ARROW_T>::ValueT;
 
  public:
   Status Partition(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
@@ -132,54 +141,58 @@ class NumericHashPartitionKernel : public HashPartitionKernel {
                    std::vector<uint32_t> &partition_histogram) override {
     if (partition_histogram.size() != num_partitions
         || target_partitions.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "target partitions or histogram not initialized!");
+      return {Code::Invalid, "target partitions or histogram not initialized!"};
     }
 
-    Partitioner partitioner = get_partitioner(num_partitions);
-    const int len = sizeof(ARROW_CTYPE);
-    LoopRunner<ARROW_ARRAY_T> loop_runner = [&](const std::shared_ptr<ARROW_ARRAY_T> &carr,
-                                                uint64_t global_idx,
-                                                uint64_t idx) {
-      ARROW_CTYPE val = carr->Value(idx);
-      uint32_t hash = 0;
-      util::MurmurHash3_x86_32(&val, len, 0, &hash);
-      hash += 31 * target_partitions[global_idx];
-      uint32_t p = partitioner(hash);
-      target_partitions[global_idx] = p;
-      partition_histogram[p]++;
-    };
-    run_loop(idx_col, loop_runner);
-
-    return Status::OK();
+    constexpr int len = sizeof(ValueT);
+    if (if_power2(num_partitions)) {
+      return visit_chunked_array<ARROW_T>(idx_col,
+                                          [&](uint64_t global_idx, ValueT val) {
+                                            uint32_t hash = 0;
+                                            util::MurmurHash3_x86_32(&val, len, 0, &hash);
+                                            hash += 31 * target_partitions[global_idx];
+                                            uint32_t p = mod_power2(hash, num_partitions);
+                                            target_partitions[global_idx] = p;
+                                            partition_histogram[p]++;
+                                          });
+    } else {
+      return
+          visit_chunked_array<ARROW_T>(idx_col,
+                                       [&](uint64_t global_idx, ValueT val) {
+                                         uint32_t hash = 0;
+                                         util::MurmurHash3_x86_32(&val, len, 0, &hash);
+                                         hash += 31 * target_partitions[global_idx];
+                                         uint32_t p = mod(hash, num_partitions);
+                                         target_partitions[global_idx] = p;
+                                         partition_histogram[p]++;
+                                       });
+    }
   }
 
   Status UpdateHash(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
                     std::vector<uint32_t> &partial_hashes) override {
     if (partial_hashes.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "partial hashes size != idx col length!");
+      return {Code::Invalid, "partial hashes size != idx col length!"};
     }
-    const int len = sizeof(ARROW_CTYPE);
-    LoopRunner<ARROW_ARRAY_T> loop_runner = [&](const std::shared_ptr<ARROW_ARRAY_T> &carr,
-                                                uint64_t global_idx,
-                                                uint64_t idx) {
-      ARROW_CTYPE val = carr->Value(idx);
-      uint32_t hash = 0;
-      util::MurmurHash3_x86_32(&val, len, 0, &hash);
-      hash += 31 * partial_hashes[global_idx];
-      partial_hashes[global_idx] = hash;
-    };
-    run_loop(idx_col, loop_runner);
-    return Status::OK();
+    constexpr int len = sizeof(ValueT);
+
+    return visit_chunked_array<ARROW_T>(idx_col,
+                                        [&](uint64_t global_idx, ValueT val) {
+                                          uint32_t hash = 0;
+                                          util::MurmurHash3_x86_32(&val, len, 0, &hash);
+                                          hash += 31 * partial_hashes[global_idx];
+                                          partial_hashes[global_idx] = hash;
+                                        });
   }
 
   uint32_t ToHash(const std::shared_ptr<arrow::Array> &values, int64_t index) override {
     if (values->IsNull(index)) {
       return 0;
     } else {
-      auto reader = std::static_pointer_cast<ARROW_ARRAY_T>(values);
-      ARROW_CTYPE lValue = reader->Value(index);
+      auto reader = std::static_pointer_cast<ArrayT>(values);
+      ValueT lValue = reader->Value(index);
       uint32_t hash = 0;
-      cylon::util::MurmurHash3_x86_32(&lValue, sizeof(ARROW_CTYPE), 0, &hash);
+      cylon::util::MurmurHash3_x86_32(&lValue, sizeof(ValueT), 0, &hash);
       return hash;
     }
   }
@@ -204,44 +217,53 @@ class FixedSizeBinaryHashPartitionKernel : public HashPartitionKernel {
                    std::vector<uint32_t> &partition_histogram) override {
     if (partition_histogram.size() != num_partitions
         || target_partitions.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "target partitions or histogram not initialized!");
+      return {Code::Invalid, "target partitions or histogram not initialized!"};
     }
 
-    Partitioner partitioner = get_partitioner(num_partitions);
-    int32_t byte_width = std::static_pointer_cast<arrow::FixedSizeBinaryType>(idx_col->type())->byte_width();
-    LoopRunner<arrow::FixedSizeBinaryArray> loop_runner = [&](const std::shared_ptr<arrow::FixedSizeBinaryArray> &carr,
-                                                              uint64_t global_idx,
-                                                              uint64_t idx) {
-      uint32_t hash = 0;
-      util::MurmurHash3_x86_32(carr->GetValue(idx), byte_width, 0, &hash);
-      hash += 31 * target_partitions[global_idx];
-      uint32_t p = partitioner(hash);
-      target_partitions[global_idx] = p;
-      partition_histogram[p]++;
-    };
-    run_loop(idx_col, loop_runner);
+    const int32_t len = std::static_pointer_cast<arrow::FixedSizeBinaryType>(idx_col->type())->byte_width();
 
-    return Status::OK();
+    if (if_power2(num_partitions)) {
+      return
+          visit_chunked_array<arrow::FixedSizeBinaryType>(
+              idx_col,
+              [&](uint64_t global_idx, arrow::util::string_view val) {
+                uint32_t hash = 0;
+                util::MurmurHash3_x86_32(&val, len, 0, &hash);
+                hash += 31 * target_partitions[global_idx];
+                uint32_t p = mod_power2(hash, num_partitions);
+                target_partitions[global_idx] = p;
+                partition_histogram[p]++;
+              });
+    } else {
+      return visit_chunked_array<arrow::FixedSizeBinaryType>(
+          idx_col,
+          [&](uint64_t global_idx, arrow::util::string_view val) {
+            uint32_t hash = 0;
+            util::MurmurHash3_x86_32(&val, len, 0, &hash);
+            hash += 31 * target_partitions[global_idx];
+            uint32_t p = mod(hash, num_partitions);
+            target_partitions[global_idx] = p;
+            partition_histogram[p]++;
+          });
+    }
   }
 
   Status UpdateHash(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
                     std::vector<uint32_t> &partial_hashes) override {
     if (partial_hashes.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "partial hashes size != idx col length!");
+      return {Code::Invalid, "partial hashes size != idx col length!"};
     }
 
     int32_t byte_width = std::static_pointer_cast<arrow::FixedSizeBinaryType>(idx_col->type())->byte_width();
-    LoopRunner<arrow::FixedSizeBinaryArray> loop_runner = [&](const std::shared_ptr<arrow::FixedSizeBinaryArray> &carr,
-                                                              uint64_t global_idx,
-                                                              uint64_t idx) {
-      uint32_t hash = 0;
-      util::MurmurHash3_x86_32(carr->GetValue(idx), byte_width, 0, &hash);
-      hash += 31 * partial_hashes[global_idx];
-      partial_hashes[global_idx] = hash;
-    };
-    run_loop(idx_col, loop_runner);
 
-    return Status::OK();
+    return visit_chunked_array<arrow::FixedSizeBinaryType>
+        (idx_col,
+         [&](uint64_t global_idx, arrow::util::string_view val) {
+           uint32_t hash = 0;
+           util::MurmurHash3_x86_32(&val, byte_width, 0, &hash);
+           hash += 31 * partial_hashes[global_idx];
+           partial_hashes[global_idx] = hash;
+         });
   }
 };
 
@@ -251,7 +273,7 @@ class BinaryHashPartitionKernel : public HashPartitionKernel {
     if (values->IsNull(index)) {
       return 0;
     } else {
-      auto reader = std::static_pointer_cast<arrow::BinaryArray>(values);
+      const auto &reader = std::static_pointer_cast<arrow::BinaryArray>(values);
       int length = 0;
       const uint8_t *val = reader->GetValue(index, &length);
       uint32_t hash = 0;
@@ -266,46 +288,51 @@ class BinaryHashPartitionKernel : public HashPartitionKernel {
                    std::vector<uint32_t> &partition_histogram) override {
     if (partition_histogram.size() != num_partitions
         || target_partitions.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "target partitions or histogram not initialized!");
+      return {Code::Invalid, "target partitions or histogram not initialized!"};
     }
 
-    Partitioner partitioner = get_partitioner(num_partitions);
-    LoopRunner<arrow::BinaryArray> loop_runner = [&](const std::shared_ptr<arrow::BinaryArray> &carr,
-                                                     uint64_t global_idx,
-                                                     uint64_t idx) {
-      int32_t byte_width = 0;
-      uint32_t hash = 0;
-      const uint8_t *val = carr->GetValue(idx, &byte_width);
-      util::MurmurHash3_x86_32(val, byte_width, 0, &hash);
-      hash += 31 * target_partitions[global_idx];
-      uint32_t p = partitioner(hash);
-      target_partitions[global_idx] = p;
-      partition_histogram[p]++;
-    };
-    run_loop(idx_col, loop_runner);
-
-    return Status::OK();
+    if (if_power2(num_partitions)) {
+      return
+          visit_chunked_array<arrow::FixedSizeBinaryType>(
+              idx_col,
+              [&](uint64_t global_idx, arrow::util::string_view val) {
+                uint32_t hash = 0;
+                util::MurmurHash3_x86_32(&val, static_cast<int>(val.size()), 0, &hash);
+                hash += 31 * target_partitions[global_idx];
+                uint32_t p = mod_power2(hash, num_partitions);
+                target_partitions[global_idx] = p;
+                partition_histogram[p]++;
+              });
+    } else {
+      return
+          visit_chunked_array<arrow::FixedSizeBinaryType>(
+              idx_col,
+              [&](uint64_t global_idx, arrow::util::string_view val) {
+                uint32_t hash = 0;
+                util::MurmurHash3_x86_32(&val, static_cast<int>(val.size()), 0, &hash);
+                hash += 31 * target_partitions[global_idx];
+                uint32_t p = mod(hash, num_partitions);
+                target_partitions[global_idx] = p;
+                partition_histogram[p]++;
+              });
+    }
   }
 
   Status UpdateHash(const std::shared_ptr<arrow::ChunkedArray> &idx_col,
                     std::vector<uint32_t> &partial_hashes) override {
     if (partial_hashes.size() != (size_t) idx_col->length()) {
-      return Status(Code::Invalid, "partial hashes size != idx col length!");
+      return {Code::Invalid, "partial hashes size != idx col length!"};
     }
 
-    LoopRunner<arrow::BinaryArray> loop_runner = [&](const std::shared_ptr<arrow::BinaryArray> &carr,
-                                                     uint64_t global_idx,
-                                                     uint64_t idx) {
-      int32_t byte_width = 0;
-      uint32_t hash = 0;
-      const uint8_t *val = carr->GetValue(idx, &byte_width);
-      util::MurmurHash3_x86_32(val, byte_width, 0, &hash);
-      hash += 31 * partial_hashes[global_idx];
-      partial_hashes[global_idx] = hash;
-    };
-    run_loop(idx_col, loop_runner);
-
-    return Status::OK();
+    return
+        visit_chunked_array<arrow::FixedSizeBinaryType>(
+            idx_col,
+            [&](uint64_t global_idx, arrow::util::string_view val) {
+              uint32_t hash = 0;
+              util::MurmurHash3_x86_32(&val, static_cast<int>(val.size()), 0, &hash);
+              hash += 31 * partial_hashes[global_idx];
+              partial_hashes[global_idx] = hash;
+            });
   }
 };
 
@@ -337,9 +364,9 @@ std::unique_ptr<HashPartitionKernel> CreateHashPartitionKernel(const std::shared
 template<typename ARROW_T, typename = typename std::enable_if<
     arrow::is_number_type<ARROW_T>::value | arrow::is_boolean_type<ARROW_T>::value>::type>
 class RangePartitionKernel : public PartitionKernel {
-  using ARROW_ARRAY_T = typename arrow::TypeTraits<ARROW_T>::ArrayType;
-  using ARROW_SCALAR_T = typename arrow::TypeTraits<ARROW_T>::ScalarType;
-  using ARROW_C_T = typename arrow::TypeTraits<ARROW_T>::CType;
+  using ArrayT = typename cylon::ArrowTypeTraits<ARROW_T>::ArrayT;
+  using ScalarT = typename cylon::ArrowTypeTraits<ARROW_T>::ScalarT;
+  using ValueT = typename cylon::ArrowTypeTraits<ARROW_T>::ValueT;
 
  public:
   RangePartitionKernel(const std::shared_ptr<CylonContext> &ctx,
@@ -362,18 +389,14 @@ class RangePartitionKernel : public PartitionKernel {
     partition_histogram.resize(num_partitions, 0);
     target_partitions.resize(idx_col->length());
 
-    LoopRunner<ARROW_ARRAY_T> loop_runner = [&](const std::shared_ptr<ARROW_ARRAY_T> &carr,
-                                                uint64_t global_idx,
-                                                uint64_t idx) {
-      ARROW_C_T val = carr->Value(idx);
-      uint32_t p = ascending ?
-                   bin_to_partition[get_bin_pos(val)] : num_partitions - 1 - bin_to_partition[get_bin_pos(val)];
-      target_partitions[global_idx] = p;
-      partition_histogram[p]++;
-    };
-    run_loop(idx_col, loop_runner);
-
-    return Status::OK();
+    return visit_chunked_array<ARROW_T>(
+        idx_col,
+        [&](uint64_t global_idx, ValueT val) {
+          uint32_t p = ascending ?
+                       bin_to_partition[get_bin_pos(val)] : num_partitions - 1 - bin_to_partition[get_bin_pos(val)];
+          target_partitions[global_idx] = p;
+          partition_histogram[p]++;
+        });
   }
 
  private:
@@ -381,7 +404,8 @@ class RangePartitionKernel : public PartitionKernel {
     const std::shared_ptr<DataType> &data_type = tarrow::ToCylonType(idx_col->type());
     std::shared_ptr<arrow::ChunkedArray> sampled_array;
 
-    if ((uint64_t) idx_col->length() == num_samples) { // if len == num_samples, dont sample, just use idx col as it is!
+    if ((uint64_t) idx_col->length()
+        == num_samples) { // if len == num_samples, dont sample, just use idx col as it is!
       sampled_array = std::make_shared<arrow::ChunkedArray>(idx_col->chunks());
     } else { // else, sample idx_col for num_samples
       std::shared_ptr<arrow::Array> samples;
@@ -394,16 +418,16 @@ class RangePartitionKernel : public PartitionKernel {
     RETURN_CYLON_STATUS_IF_FAILED(compute::MinMax(ctx, sampled_array, data_type, minmax));
 
     const auto &struct_scalar = minmax->GetResult().scalar_as<arrow::StructScalar>();
-    min = std::static_pointer_cast<ARROW_SCALAR_T>(struct_scalar.value[0])->value;
-    max = std::static_pointer_cast<ARROW_SCALAR_T>(struct_scalar.value[1])->value;
+    min = std::static_pointer_cast<ScalarT>(struct_scalar.value[0])->value;
+    max = std::static_pointer_cast<ScalarT>(struct_scalar.value[1])->value;
     range = max - min;
 
     // create sample histogram
     std::vector<uint64_t> local_counts(num_bins + 2, 0);
     for (const auto &arr: sampled_array->chunks()) {
-      const std::shared_ptr<ARROW_ARRAY_T> &casted_arr = std::static_pointer_cast<ARROW_ARRAY_T>(arr);
+      const std::shared_ptr<ArrayT> &casted_arr = std::static_pointer_cast<ArrayT>(arr);
       for (int64_t i = 0; i < casted_arr->length(); i++) {
-        ARROW_C_T val = casted_arr->Value(i);
+        ValueT val = casted_arr->Value(i);
         local_counts[get_bin_pos(val)]++;
       }
     }
@@ -420,7 +444,7 @@ class RangePartitionKernel : public PartitionKernel {
       global_counts_ptr = &local_counts;
     }
 
-    float_t quantile = 1.0 / num_partitions, prefix_sum = 0;
+    float_t quantile = float(1.0 / num_partitions), prefix_sum = 0;
 
     LOG(INFO) << "len=" << idx_col->length() << " min=" << min << " max=" << max << " range=" <<
               range << " num bins=" << num_bins << " quantile=" << quantile;
@@ -429,7 +453,7 @@ class RangePartitionKernel : public PartitionKernel {
     const uint64_t total_samples = ctx->GetWorldSize() * num_samples;
     uint32_t curr_partition = 0;
     float_t target_quantile = quantile;
-    for (const auto &c:*global_counts_ptr) {
+    for (const auto &c: *global_counts_ptr) {
       bin_to_partition.push_back(curr_partition);
       float_t freq = (float_t) c / total_samples;
       prefix_sum += freq;
@@ -445,7 +469,7 @@ class RangePartitionKernel : public PartitionKernel {
     return Status::OK();
   }
 
-  inline constexpr size_t get_bin_pos(ARROW_C_T val) {
+  inline constexpr size_t get_bin_pos(ValueT val) {
     return (val >= min)
         + ((val >= min) & (val < max)) * ((val - min) * num_bins / range)
         + (val >= max) * num_bins;
@@ -456,7 +480,7 @@ class RangePartitionKernel : public PartitionKernel {
   const uint64_t num_samples;
   const std::shared_ptr<CylonContext> &ctx;
   std::vector<uint32_t> bin_to_partition;
-  ARROW_C_T min, max, range;
+  ValueT min, max, range;
 };
 
 std::unique_ptr<PartitionKernel> CreateRangePartitionKernel(const std::shared_ptr<arrow::DataType> &data_type,
@@ -525,15 +549,19 @@ std::unique_ptr<PartitionKernel> CreateRangePartitionKernel(const std::shared_pt
 }
 
 RowHashingKernel::RowHashingKernel(const std::vector<std::shared_ptr<arrow::Field>> &fields) {
-  for (auto const &field : fields) {
+  for (auto const &field: fields) {
     this->hash_kernels.push_back(CreateHashPartitionKernel(field->type()));
   }
 }
 
 int32_t RowHashingKernel::Hash(const std::shared_ptr<arrow::Table> &table, int64_t row) const {
-  int64_t hash_code = 1;
+  if (table->num_rows() == 0) {
+    return 0;
+  }
+
+  int32_t hash_code = 1;
   for (int c = 0; c < table->num_columns(); ++c) {
-    hash_code = 31 * hash_code + this->hash_kernels[c]->ToHash(cylon::util::GetChunkOrEmptyArray(table->column(c), 0), row);
+    hash_code = static_cast<int32_t>(31 * hash_code + this->hash_kernels[c]->ToHash(table->column(c)->chunk(0), row));
   }
   return hash_code;
 }

--- a/cpp/src/cylon/arrow/arrow_task_all_to_all.cpp
+++ b/cpp/src/cylon/arrow/arrow_task_all_to_all.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include <cylon/arrow/arrow_task_all_to_all.h>
+#include <cylon/util/macros.hpp>
 
 cylon::LogicalTaskPlan::LogicalTaskPlan(std::shared_ptr<std::vector<int>> task_source,
                                         std::shared_ptr<std::vector<int>> task_targets,
@@ -42,7 +43,7 @@ const std::shared_ptr<std::unordered_map<int, int>> &cylon::LogicalTaskPlan::Get
   return task_to_worker;
 }
 
-cylon::ArrowTaskAllToAll::ArrowTaskAllToAll(std::shared_ptr<cylon::CylonContext> ctx,
+cylon::ArrowTaskAllToAll::ArrowTaskAllToAll(const std::shared_ptr<CylonContext> &ctx,
                                             const cylon::LogicalTaskPlan &plan,
                                             int edgeId,
                                             ArrowTaskCallBack callback,
@@ -52,6 +53,7 @@ cylon::ArrowTaskAllToAll::ArrowTaskAllToAll(std::shared_ptr<cylon::CylonContext>
                     *plan.GetWorkerTargets(),
                     edgeId,
                     [&callback](int worker_source, const std::shared_ptr<arrow::Table> &table, int target_task) {
+                      CYLON_UNUSED(worker_source);
                       return callback(table, target_task);
                     },
                     schema),

--- a/cpp/src/cylon/arrow/arrow_task_all_to_all.h
+++ b/cpp/src/cylon/arrow/arrow_task_all_to_all.h
@@ -60,7 +60,7 @@ class ArrowTaskAllToAll : public ArrowAllToAll {
   const LogicalTaskPlan &plan;
 
  public:
-  ArrowTaskAllToAll(std::shared_ptr<cylon::CylonContext> ctx,
+  ArrowTaskAllToAll(const std::shared_ptr<CylonContext> &ctx,
                     const LogicalTaskPlan &plan,
                     int edgeId,
                     ArrowTaskCallBack callback,

--- a/cpp/src/cylon/arrow/arrow_type_traits.hpp
+++ b/cpp/src/cylon/arrow/arrow_type_traits.hpp
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CYLON_CPP_SRC_CYLON_ARROW_ARROW_TYPE_TRAITS_HPP_
+#define CYLON_CPP_SRC_CYLON_ARROW_ARROW_TYPE_TRAITS_HPP_
+
+namespace cylon {
+
+template<typename ArrowT, typename Enable = void>
+struct ArrowTypeTraits {};
+
+template<typename ArrowT>
+struct ArrowTypeTraits<ArrowT, arrow::enable_if_has_c_type<ArrowT>> {
+  using ScalarT = typename arrow::TypeTraits<ArrowT>::ScalarType;
+  using ArrayT = typename arrow::TypeTraits<ArrowT>::ArrayType;
+  using ValueT = typename ArrowT::c_type;
+
+  static ValueT ExtractFromScalar(const std::shared_ptr<arrow::Scalar> &scalar) {
+    return std::static_pointer_cast<ScalarT>(scalar)->value;
+  }
+};
+
+template<typename ArrowT>
+struct ArrowTypeTraits<ArrowT, arrow::enable_if_has_string_view<ArrowT>> {
+  using ScalarT = typename arrow::TypeTraits<ArrowT>::ScalarType;
+  using ArrayT = typename arrow::TypeTraits<ArrowT>::ArrayType;
+  using ValueT = arrow::util::string_view;
+
+  static ValueT ExtractFromScalar(const std::shared_ptr<arrow::Scalar> &scalar) {
+    return ValueT(*(std::static_pointer_cast<ScalarT>(scalar))->value);
+  }
+};
+} // cylon
+
+#endif //CYLON_CPP_SRC_CYLON_ARROW_ARROW_TYPE_TRAITS_HPP_

--- a/cpp/src/cylon/compute/aggregate_utils.hpp
+++ b/cpp/src/cylon/compute/aggregate_utils.hpp
@@ -117,7 +117,7 @@ cylon::Status AllReduce(cylon::net::CommType comm_type,
   }
 }
 
-template<typename RED_OPS=cylon::net::ReduceOp>
+template<typename RED_OPS>
 cylon::Status DoAllReduce(const std::shared_ptr<CylonContext> &ctx,
                           const arrow::Datum &snd,
                           std::shared_ptr<Result> &rcv,

--- a/cpp/src/cylon/compute/aggregates.cpp
+++ b/cpp/src/cylon/compute/aggregates.cpp
@@ -26,40 +26,37 @@ namespace compute {
 cylon::Status Sum(const std::shared_ptr<cylon::Table> &table,
                   int32_t col_idx,
                   std::shared_ptr<Result> &output) {
-  const auto& ctx = table->GetContext();
-  const std::shared_ptr<Column> &col = table->GetColumn(col_idx); // cylon column object
-  const std::shared_ptr<DataType> &data_type = col->GetDataType();
-  const arrow::Datum input(col->GetColumnData()); // input datum
+  const auto &ctx = table->GetContext();
+  const auto &a_table = table->get_table();
+  const auto &a_col = a_table->column(col_idx);
+  const auto &dtype = tarrow::ToCylonType(a_col->type());
 
   // do local operation
   arrow::compute::ExecContext exec_ctx(cylon::ToArrowPool(ctx));
-  const arrow::Result<arrow::Datum> &sum_res = arrow::compute::Sum(input, &exec_ctx);
-  RETURN_CYLON_STATUS_IF_ARROW_FAILED(sum_res.status());
+  CYLON_ASSIGN_OR_RAISE(auto sum_res, arrow::compute::Sum(a_col, &exec_ctx));
 
   if (ctx->GetWorldSize() > 1) {
-    return DoAllReduce(ctx, sum_res.ValueOrDie(), output, data_type, cylon::net::ReduceOp::SUM);
+    return DoAllReduce(ctx, sum_res, output, dtype, cylon::net::ReduceOp::SUM);
   } else {
-    output = std::make_shared<Result>(sum_res.ValueOrDie());
+    output = std::make_shared<Result>(sum_res);
     return Status::OK();
   }
 }
 
 cylon::Status Count(const std::shared_ptr<cylon::Table> &table, int32_t col_idx, std::shared_ptr<Result> &output) {
-  const auto& ctx = table->GetContext();
-
-  const std::shared_ptr<Column> &col = table->GetColumn(col_idx);
-  const std::shared_ptr<DataType> &data_type = cylon::Int64();
-  const arrow::Datum input(col->GetColumnData()); // input datum
+  const auto &ctx = table->GetContext();
+  const auto &a_table = table->get_table();
+  const auto &a_col = a_table->column(col_idx);
+  const auto &data_type = cylon::Int64();
 
   arrow::compute::ExecContext exec_ctx(cylon::ToArrowPool(ctx));
   arrow::compute::CountOptions options(arrow::compute::CountOptions::COUNT_NON_NULL);
-  const arrow::Result<arrow::Datum> &count_res = arrow::compute::Count(input, options, &exec_ctx);
-  RETURN_CYLON_STATUS_IF_ARROW_FAILED(count_res.status());
+  CYLON_ASSIGN_OR_RAISE(auto count_res, arrow::compute::Count(a_col, options, &exec_ctx));
 
   if (ctx->GetWorldSize() > 1) {
-    return DoAllReduce(ctx, count_res.ValueOrDie(), output, data_type, cylon::net::ReduceOp::SUM);
+    return DoAllReduce(ctx, count_res, output, data_type, cylon::net::ReduceOp::SUM);
   } else {
-    output = std::make_shared<Result>(count_res.ValueOrDie());
+    output = std::make_shared<Result>(count_res);
     return Status::OK();
   }
 }
@@ -90,11 +87,9 @@ cylon::Status static inline min_max_impl(const std::shared_ptr<CylonContext> &ct
 
   arrow::compute::ExecContext exec_context(cylon::ToArrowPool(ctx));
   arrow::compute::MinMaxOptions options(arrow::compute::MinMaxOptions::SKIP);
-  const arrow::Result<arrow::Datum> &result = arrow::compute::MinMax(input, options, &exec_context);
-  RETURN_CYLON_STATUS_IF_ARROW_FAILED(result.status());
+  CYLON_ASSIGN_OR_RAISE(auto result, arrow::compute::MinMax(input, options, &exec_context));
 
-  const arrow::Datum &local_result = result.ValueOrDie(); // minmax returns a structscalar
-  const auto &struct_scalar = local_result.scalar_as<arrow::StructScalar>();
+  const auto &struct_scalar = result.scalar_as<arrow::StructScalar>();
 
   switch (minMaxOpts) {
     case min:
@@ -111,37 +106,44 @@ cylon::Status static inline min_max_impl(const std::shared_ptr<CylonContext> &ct
                          cylon::net::ReduceOp::MAX);
     case minmax:
       return DoAllReduce<std::vector<cylon::net::ReduceOp>>(ctx,
-                                                            local_result,
+                                                            result,
                                                             output,
                                                             data_type,
                                                             {cylon::net::ReduceOp::MIN,
                                                              cylon::net::ReduceOp::MAX});
   }
-  return Status(); // this would never reach
+  return Status::OK(); // this would never reach
 }
 
 cylon::Status Min(const std::shared_ptr<cylon::Table> &table,
                   int32_t col_idx,
                   std::shared_ptr<Result> &output) {
-  const auto& ctx = table->GetContext();
-  const std::shared_ptr<Column> &col = table->GetColumn(col_idx);
-  return min_max_impl<MinMaxOpts::min>(ctx, col->GetColumnData(), col->GetDataType(), output);
+  const auto &ctx = table->GetContext();
+  const auto &a_table = table->get_table();
+  const auto &a_col = a_table->column(col_idx);
+  const auto &dtype = tarrow::ToCylonType(a_col->type());
+
+  return min_max_impl<MinMaxOpts::min>(ctx, a_col, dtype, output);
 }
 
 cylon::Status Max(const std::shared_ptr<cylon::Table> &table,
                   int32_t col_idx,
                   std::shared_ptr<Result> &output) {
-  const auto& ctx = table->GetContext();
-  const std::shared_ptr<Column> &col = table->GetColumn(col_idx);
-  return min_max_impl<MinMaxOpts::max>(ctx, col->GetColumnData(), col->GetDataType(), output);
+  const auto &ctx = table->GetContext();
+  const auto &a_table = table->get_table();
+  const auto &a_col = a_table->column(col_idx);
+  const auto &dtype = tarrow::ToCylonType(a_col->type());
+  return min_max_impl<MinMaxOpts::max>(ctx, a_col, dtype, output);
 }
 
 cylon::Status MinMax(const std::shared_ptr<cylon::Table> &table,
                      int32_t col_idx,
                      std::shared_ptr<Result> &output) {
-  const auto& ctx = table->GetContext();
-  const std::shared_ptr<Column> &col = table->GetColumn(col_idx);
-  return min_max_impl<MinMaxOpts::minmax>(ctx, col->GetColumnData(), col->GetDataType(), output);
+  const auto &ctx = table->GetContext();
+  const auto &a_table = table->get_table();
+  const auto &a_col = a_table->column(col_idx);
+  const auto &dtype = tarrow::ToCylonType(a_col->type());
+  return min_max_impl<MinMaxOpts::minmax>(ctx, a_col, dtype, output);
 }
 
 cylon::Status MinMax(const std::shared_ptr<CylonContext> &ctx,

--- a/cpp/src/cylon/net/buffer.hpp
+++ b/cpp/src/cylon/net/buffer.hpp
@@ -34,6 +34,7 @@ namespace cylon {
    */
   class Allocator {
   public:
+    virtual ~Allocator() = default;
     virtual Status Allocate(int64_t length, std::shared_ptr<Buffer> *buffer) = 0;
   };
 
@@ -53,8 +54,7 @@ namespace cylon {
 
   class DefaultAllocator : public Allocator {
    public:
-    cylon::Status Allocate(int64_t length,
-        std::shared_ptr<Buffer> *buffer) override {
+    cylon::Status Allocate(int64_t length, std::shared_ptr<Buffer> *buffer) override {
       auto *b = new uint8_t[length];
       *buffer = std::make_shared<DefaultBuffer>(b, length);
       return Status::OK();

--- a/cpp/src/cylon/net/channel.hpp
+++ b/cpp/src/cylon/net/channel.hpp
@@ -29,6 +29,8 @@ namespace cylon {
  */
 class ChannelSendCallback {
  public:
+  virtual ~ChannelSendCallback() = default;
+
   virtual void sendComplete(std::shared_ptr<TxRequest> request) = 0;
 
   virtual void sendFinishComplete(std::shared_ptr<TxRequest> request) = 0;
@@ -39,6 +41,8 @@ class ChannelSendCallback {
  */
 class ChannelReceiveCallback {
  public:
+  virtual ~ChannelReceiveCallback() = default;
+
   virtual void receivedData(int receiveId, std::shared_ptr<Buffer> buffer, int length) = 0;
 
   virtual void receivedHeader(int receiveId, int finished, int *header, int headerLength) = 0;

--- a/cpp/src/cylon/net/communicator.hpp
+++ b/cpp/src/cylon/net/communicator.hpp
@@ -27,7 +27,7 @@ class Communicator {
   int world_size = -1;
  public:
   virtual Status Init(const std::shared_ptr<CommConfig> &config) = 0;
-  virtual Channel *CreateChannel() = 0;
+  virtual std::unique_ptr<Channel> CreateChannel() const = 0;
   virtual int GetRank() const = 0;
   virtual int GetWorldSize() const = 0;
   virtual void Finalize() = 0;

--- a/cpp/src/cylon/net/mpi/mpi_channel.hpp
+++ b/cpp/src/cylon/net/mpi/mpi_channel.hpp
@@ -108,6 +108,8 @@ class MPIChannel : public Channel {
 
   void close() override;
 
+  ~MPIChannel() override = default;
+
  private:
   int edge;
   // keep track of the length buffers for each receiver

--- a/cpp/src/cylon/net/mpi/mpi_communicator.cpp
+++ b/cpp/src/cylon/net/mpi/mpi_communicator.cpp
@@ -37,10 +37,12 @@ std::shared_ptr<MPIConfig> MPIConfig::Make() {
   return std::make_shared<MPIConfig>();
 }
 
-MPIConfig::~MPIConfig() {}
+MPIConfig::~MPIConfig() = default;
 
 Channel *MPICommunicator::CreateChannel() {
-  return new MPIChannel();
+  Channel *channel = new MPIChannel();
+  channels_.push_back(channel);
+  return channel;
 }
 
 int MPICommunicator::GetRank() const {
@@ -65,8 +67,8 @@ void MPICommunicator::Finalize() {
   int finalized;
   MPI_Finalized(&finalized);
   if (!finalized) {
-	MPI_Finalize();
-  } 
+    MPI_Finalize();
+  }
 }
 void MPICommunicator::Barrier() {
   MPI_Barrier(MPI_COMM_WORLD);
@@ -74,6 +76,13 @@ void MPICommunicator::Barrier() {
 
 CommType MPICommunicator::GetCommType() const {
   return MPI;
+}
+
+MPICommunicator::~MPICommunicator() {
+  for (auto &&c: channels_) {
+    delete c;
+  }
+  channels_.clear();
 }
 }  // namespace net
 }  // namespace cylon

--- a/cpp/src/cylon/net/mpi/mpi_communicator.cpp
+++ b/cpp/src/cylon/net/mpi/mpi_communicator.cpp
@@ -39,10 +39,8 @@ std::shared_ptr<MPIConfig> MPIConfig::Make() {
 
 MPIConfig::~MPIConfig() = default;
 
-Channel *MPICommunicator::CreateChannel() {
-  Channel *channel = new MPIChannel();
-  channels_.push_back(channel);
-  return channel;
+std::unique_ptr<Channel> MPICommunicator::CreateChannel() const {
+  return std::make_unique<MPIChannel>();
 }
 
 int MPICommunicator::GetRank() const {
@@ -76,13 +74,6 @@ void MPICommunicator::Barrier() {
 
 CommType MPICommunicator::GetCommType() const {
   return MPI;
-}
-
-MPICommunicator::~MPICommunicator() {
-  for (auto &&c: channels_) {
-    delete c;
-  }
-  channels_.clear();
 }
 }  // namespace net
 }  // namespace cylon

--- a/cpp/src/cylon/net/mpi/mpi_communicator.hpp
+++ b/cpp/src/cylon/net/mpi/mpi_communicator.hpp
@@ -34,17 +34,14 @@ public:
 
 class MPICommunicator : public Communicator {
  public:
-  virtual ~MPICommunicator();
+  ~MPICommunicator() override = default;
   Status Init(const std::shared_ptr<CommConfig> &config) override;
-  Channel *CreateChannel() override;
+  std::unique_ptr<Channel> CreateChannel() const override;
   int GetRank() const override;
   int GetWorldSize() const override;
   void Finalize() override;
   void Barrier() override;
   CommType GetCommType() const override;
-
- private:
-  std::vector<Channel*> channels_{};
 };
 }
 }

--- a/cpp/src/cylon/net/mpi/mpi_communicator.hpp
+++ b/cpp/src/cylon/net/mpi/mpi_communicator.hpp
@@ -28,12 +28,13 @@ class MPIConfig : public CommConfig {
   int GetDummyConfig();
 public:
   CommType Type() override;
-  virtual ~MPIConfig();
+  ~MPIConfig() override;
   static std::shared_ptr<MPIConfig> Make();
 };
 
 class MPICommunicator : public Communicator {
  public:
+  virtual ~MPICommunicator();
   Status Init(const std::shared_ptr<CommConfig> &config) override;
   Channel *CreateChannel() override;
   int GetRank() const override;
@@ -41,6 +42,9 @@ class MPICommunicator : public Communicator {
   void Finalize() override;
   void Barrier() override;
   CommType GetCommType() const override;
+
+ private:
+  std::vector<Channel*> channels_{};
 };
 }
 }

--- a/cpp/src/cylon/net/ops/all_to_all.cpp
+++ b/cpp/src/cylon/net/ops/all_to_all.cpp
@@ -58,7 +58,6 @@ void AllToAll::close() {
   sends.clear();
   // free the channel
   channel->close();
-  delete channel;
 }
 
 int AllToAll::insert(const void *buffer, int length, int target) {

--- a/cpp/src/cylon/net/ops/all_to_all.hpp
+++ b/cpp/src/cylon/net/ops/all_to_all.hpp
@@ -163,7 +163,7 @@ class AllToAll : public ChannelReceiveCallback, ChannelSendCallback {
   std::unordered_set<int> finishedSources;  // keep track of  the finished sources
   std::unordered_set<int> finishedTargets;  // keep track of  the finished targets
   bool finishFlag = false;
-  Channel *channel;             // the underlying channel
+  std::unique_ptr<Channel> channel;             // the underlying channel
   ReceiveCallback *callback;    // after we receive a buffer we will call this function
   unsigned long thisNumTargets;            // number of targets in this process, 1 or 0
   int thisNumSources;            // number of sources in this process, 1 or 0

--- a/cpp/src/cylon/net/ops/all_to_all.hpp
+++ b/cpp/src/cylon/net/ops/all_to_all.hpp
@@ -90,7 +90,7 @@ class AllToAll : public ChannelReceiveCallback, ChannelSendCallback {
            ReceiveCallback *callback,
            Allocator *alloc);
 
-  virtual ~AllToAll() = default;
+  ~AllToAll() override = default;
 
   /**
    * Insert a buffer to be sent, if the buffer is accepted return true

--- a/cpp/src/cylon/net/ucx/ucx_channel.hpp
+++ b/cpp/src/cylon/net/ucx/ucx_channel.hpp
@@ -85,6 +85,13 @@ struct PendingReceive {
 class UCXChannel : public Channel {
  public:
   /**
+ * Link the necessary parameters associated with the communicator to the channel
+ * @param [in] com - The UCX communicator that created the channel
+ * @return
+ */
+  explicit UCXChannel(const net::UCXCommunicator *com);
+
+  /**
    * Initialize the channel
    *
    * @param receives receive from these ranks
@@ -92,9 +99,9 @@ class UCXChannel : public Channel {
   void init(int edge,
             const std::vector<int> &receives,
             const std::vector<int> &sendIds,
-			ChannelReceiveCallback *rcv,
-			ChannelSendCallback *send,
-			Allocator *alloc) override;
+            ChannelReceiveCallback *rcv,
+            ChannelSendCallback *send,
+            Allocator *alloc) override;
 
   /**
   * Send the message to the target.
@@ -124,13 +131,6 @@ class UCXChannel : public Channel {
 
   void close() override;
 
-  /**
-   * Link the necessary parameters associated with the communicator to the channel
-   * @param [in] com - The UCX communicator that created the channel
-   * @return
-   */
-  void linkCommunicator(net::UCXCommunicator* com);
-
  private:
   int edge;
   // keep track of the length buffers for each receiver
@@ -152,9 +152,9 @@ class UCXChannel : public Channel {
 
   // # UCX specific attributes
   // The worker for receiving
-  ucp_worker_h*  ucpRecvWorker;
+  const ucp_worker_h *ucpRecvWorker;
   // The worker for sending
-  ucp_worker_h*  ucpSendWorker;
+  const ucp_worker_h *ucpSendWorker;
   // Endpoint Map
   std::unordered_map<int, ucp_ep_h> endPointMap;
   // Tag mask used to match UCX send / receives
@@ -193,15 +193,13 @@ class UCXChannel : public Channel {
    * Send finish request
    * @param x the target, pendingSend pair
    */
-  void sendFinishHeader(const std::pair<const int,
-                        PendingSend *> &x) const;
+  void sendFinishHeader(const std::pair<const int, PendingSend *> &x) const;
 
   /**
    * Send the length
    * @param x the target, pendingSend pair
    */
-  void sendHeader(const std::pair<const int,
-                  PendingSend *> &x) const;
+  void sendHeader(const std::pair<const int, PendingSend *> &x) const;
 };
 }
 

--- a/cpp/src/cylon/net/ucx/ucx_communicator.cpp
+++ b/cpp/src/cylon/net/ucx/ucx_communicator.cpp
@@ -17,6 +17,7 @@
 #include <cylon/net/communicator.hpp>
 #include <cylon/net/ucx/ucx_communicator.hpp>
 #include <cylon/net/ucx/ucx_channel.hpp>
+#include <cylon/util/macros.hpp>
 
 namespace cylon {
 namespace net {
@@ -35,10 +36,8 @@ std::shared_ptr<UCXConfig> UCXConfig::Make() {
   return std::make_shared<UCXConfig>();
 }
 
-Channel *UCXCommunicator::CreateChannel() {
-  auto newChannel = new UCXChannel();
-  newChannel->linkCommunicator(this);
-  return newChannel;
+std::unique_ptr<Channel> UCXCommunicator::CreateChannel() const {
+  return std::make_unique<UCXChannel>(this);
 }
 
 int UCXCommunicator::GetRank() const {
@@ -48,6 +47,7 @@ int UCXCommunicator::GetWorldSize() const {
   return this->world_size;
 }
 Status UCXCommunicator::Init(const std::shared_ptr<CommConfig> &config) {
+  CYLON_UNUSED(config);
   // Check init functions
   int initialized;
   // Int variable used when iterating

--- a/cpp/src/cylon/net/ucx/ucx_communicator.hpp
+++ b/cpp/src/cylon/net/ucx/ucx_communicator.hpp
@@ -38,7 +38,7 @@ class UCXConfig : public CommConfig {
 class UCXCommunicator : public Communicator {
  public:
   Status Init(const std::shared_ptr<CommConfig> &config) override;
-  Channel *CreateChannel() override;
+  std::unique_ptr<Channel> CreateChannel() const override;
   int GetRank() const override;
   int GetWorldSize() const override;
   void Finalize() override;

--- a/cpp/src/cylon/ops.cpp
+++ b/cpp/src/cylon/ops.cpp
@@ -83,8 +83,8 @@ Status UnionOperation(const std::shared_ptr <cylon::CylonContext> &ctx,
     out = table;
   };
 
-  std::vector<int> left_column_indexes(left->GetColumns().size());
-  std::vector<int> right_column_indexes(right->GetColumns().size());
+  std::vector<int> left_column_indexes(left->Columns());
+  std::vector<int> right_column_indexes(right->Columns());
   std::iota (std::begin(left_column_indexes), std::end(left_column_indexes), 0);
   std::iota (std::begin(right_column_indexes), std::end(right_column_indexes), 0);
   int left_splits = 1;
@@ -112,8 +112,8 @@ Status SubtractOperation(const std::shared_ptr <cylon::CylonContext> &ctx,
     out = table;
   };
 
-  std::vector<int> left_column_indexes(left->GetColumns().size());
-  std::vector<int> right_column_indexes(right->GetColumns().size());
+  std::vector<int> left_column_indexes(left->Columns());
+  std::vector<int> right_column_indexes(right->Columns());
   std::iota (std::begin(left_column_indexes), std::end(left_column_indexes), 0);
   std::iota (std::begin(right_column_indexes), std::end(right_column_indexes), 0);
   int left_splits = 1;
@@ -141,8 +141,8 @@ Status IntersectOperation(const std::shared_ptr <cylon::CylonContext> &ctx,
     out = table;
   };
 
-  std::vector<int> left_column_indexes(left->GetColumns().size());
-  std::vector<int> right_column_indexes(right->GetColumns().size());
+  std::vector<int> left_column_indexes(left->Columns());
+  std::vector<int> right_column_indexes(right->Columns());
   std::iota (std::begin(left_column_indexes), std::end(left_column_indexes), 0);
   std::iota (std::begin(right_column_indexes), std::end(right_column_indexes), 0);
   int left_splits = 1;

--- a/cpp/src/cylon/table.cpp
+++ b/cpp/src/cylon/table.cpp
@@ -1067,42 +1067,7 @@ const std::shared_ptr<cylon::CylonContext> &Table::GetContext() const {
 Table::Table(const std::shared_ptr<CylonContext> &ctx, std::shared_ptr<arrow::Table> tab)
     : ctx(ctx),
       table_(std::move(tab)),
-      base_arrow_index_(std::make_shared<cylon::ArrowRangeIndex>(0, table_->num_rows(), 1, cylon::ToArrowPool(ctx))) {
-//  columns_.reserve(table_->num_columns());
-//  for (int i = 0; i < table_->num_columns(); i++) {
-//    const std::shared_ptr<arrow::Field> &field = table_->field(i);
-//    columns_.emplace_back(Column::Make(field->name(), cylon::tarrow::ToCylonType(field->type()), table_->column(i)));
-//  }
-//  base_arrow_index_ = std::make_shared<cylon::ArrowRangeIndex>(0, table_->num_rows(), 1, cylon::ToArrowPool(ctx));
-}
-
-//Table::Table(const std::shared_ptr<cylon::CylonContext> &ctx, std::vector<std::shared_ptr<Column>> cols)
-//    : ctx(ctx), columns_(std::move(cols)) {
-//  arrow::SchemaBuilder schema_builder;
-//  std::vector<std::shared_ptr<arrow::ChunkedArray>> col_arrays;
-//  col_arrays.reserve(cols.size());
-//
-//  for (const std::shared_ptr<Column> &col : columns_) {
-//    const std::shared_ptr<DataType> &data_type = col->GetDataType();
-//    const std::shared_ptr<arrow::Field>
-//        &field = arrow::field(col->GetID(), cylon::tarrow::convertToArrowType(data_type));
-//    const auto &status = schema_builder.AddField(field);
-//    if (!status.ok()) {
-//      throw "unable to add field to arrow schema: " + status.message();
-//    }
-//
-//    col_arrays.push_back(col->GetColumnData());
-//  }
-//
-//  const auto &schema_result = schema_builder.Finish();
-//  table_ = arrow::Table::Make(schema_result.ValueOrDie(), std::move(col_arrays));
-//
-//  if (!cylon::tarrow::validateArrowTableTypes(table_)) {
-//    throw "cylon table created with invalid types";
-//  }
-//}
-
-
+      base_arrow_index_(std::make_shared<cylon::ArrowRangeIndex>(0, table_->num_rows(), 1, cylon::ToArrowPool(ctx))) {}
 
 #ifdef BUILD_CYLON_PARQUET
 Status FromParquet(const std::shared_ptr<CylonContext> &ctx, const std::string &path,

--- a/cpp/src/cylon/table.hpp
+++ b/cpp/src/cylon/table.hpp
@@ -52,13 +52,6 @@ class Table {
   Table(const std::shared_ptr<CylonContext> &ctx, std::shared_ptr<arrow::Table> tab);
 
   /**
-   * Table created from cylon::Column
-   * @param ctx
-   * @param cols (vector is passed by value and the copy is moved as a class member)
-   */
-  Table(const std::shared_ptr<CylonContext> &ctx, std::vector<std::shared_ptr<Column>> cols);
-
-  /**
    * Create a table from an arrow table,
    * @param table arrow::Table
    * @return
@@ -97,10 +90,10 @@ class Table {
    * @param headers the names of custom header
    * @return true if print is successful
    */
-  Status PrintToOStream(int col1, int col2, int row1, int row2, std::ostream &out,
+  Status PrintToOStream(int col1, int col2, int64_t row1, int64_t row2, std::ostream &out,
                         char delimiter = ',', bool use_custom_header = false,
-                        const std::vector<std::string> &headers = {});
-  Status PrintToOStream(std::ostream &out);
+                        const std::vector<std::string> &headers = {}) const;
+  Status PrintToOStream(std::ostream &out) const;
 
   /*END OF TRANSFORMATION FUNCTIONS*/
 
@@ -125,7 +118,7 @@ class Table {
   /**
    * Print the complete table
    */
-  void Print();
+  void Print() const;
 
   /**
    * Print the table from row1 to row2 and col1 to col2
@@ -134,7 +127,7 @@ class Table {
    * @param col1 first column to start printing (including)
    * @param col2 end column to stop printing (including)
    */
-  void Print(int row1, int row2, int col1, int col2);
+  void Print(int row1, int row2, int col1, int col2) const;
 
   /**
    * Get the underlying arrow table
@@ -165,19 +158,6 @@ class Table {
    */
   bool IsRetain() const;
 
-  /**
-   * Get a cylon::Column from the table
-   * @param index
-   * @return
-   */
-  std::shared_ptr<Column> GetColumn(int32_t index) const;
-
-  /**
-   * Get the column vector of the table
-   * @return
-   */
-  const std::vector<std::shared_ptr<cylon::Column>> &GetColumns() const;
-
   Status SetArrowIndex(std::shared_ptr<cylon::BaseArrowIndex> &index, bool drop_index);
 
   std::shared_ptr<BaseArrowIndex> GetArrowIndex();
@@ -193,7 +173,6 @@ class Table {
   const std::shared_ptr<cylon::CylonContext> ctx;
   std::shared_ptr<arrow::Table> table_;
   bool retain_ = true;
-  std::vector<std::shared_ptr<cylon::Column>> columns_;
   std::shared_ptr<cylon::BaseArrowIndex> base_arrow_index_ = nullptr;
 };
 

--- a/cpp/src/cylon/util/macros.hpp
+++ b/cpp/src/cylon/util/macros.hpp
@@ -72,4 +72,6 @@
     }                                                         \
   } while (0)
 
+#define CYLON_UNUSED(expr) do { (void)(expr); } while (0)
+
 #endif //CYLON_CPP_SRC_CYLON_UTIL_MACROS_HPP_

--- a/cpp/src/cylon/util/macros.hpp
+++ b/cpp/src/cylon/util/macros.hpp
@@ -35,10 +35,14 @@
     };                              \
   } while (0)
 
-#define CYLON_ASSIGN_OR_RAISE(lhs, rexpr) \
-  auto&& result_name = (rexpr);           \
-  RETURN_CYLON_STATUS_IF_ARROW_FAILED((result_name).status()); \
+#define CYLON_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr)     \
+  auto&& result_name = (rexpr);                                 \
+  RETURN_CYLON_STATUS_IF_ARROW_FAILED((result_name).status()) ; \
   lhs = std::move(result_name).ValueUnsafe();
+
+#define CYLON_ASSIGN_OR_RAISE(lhs, rexpr)                                              \
+  CYLON_ASSIGN_OR_RAISE_IMPL(ARROW_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), \
+                                  lhs, rexpr);
 
 #define RETURN_ARROW_STATUS_IF_FAILED(expr) \
   do{                               \

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -122,3 +122,7 @@ cylon_run_test(sorting_test 1)
 # hash utils test
 cylon_add_test(hash_utils_test)
 cylon_run_test(hash_utils_test 1)
+
+# utils test
+cylon_add_test(utils_test)
+cylon_run_test(utils_test 1)

--- a/cpp/test/aggregate_test.cpp
+++ b/cpp/test/aggregate_test.cpp
@@ -70,7 +70,7 @@ TEST_CASE("aggregate testing", "[aggregates]") {
     status = cylon::compute::Sum(table, 1, output);
     REQUIRE(status.is_ok());
 
-    auto array = output->GetColumn(0)->GetColumnData()->chunk(0);
+    auto array = output->get_table()->column(0)->chunk(0);
     auto val = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(array)->Value(0);
 
     REQUIRE(val == ((double) (rows * (rows - 1) / 2.0) + 10.0 * rows) * ctx->GetWorldSize());
@@ -80,7 +80,7 @@ TEST_CASE("aggregate testing", "[aggregates]") {
     status = cylon::compute::Count(table, 1, output);
     REQUIRE(status.is_ok());
 
-    auto array = output->GetColumn(0)->GetColumnData()->chunk(0);
+    auto array = output->get_table()->column(0)->chunk(0);
     auto val = std::static_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(array)->Value(0);
 
     REQUIRE(val == rows * ctx->GetWorldSize());
@@ -90,7 +90,7 @@ TEST_CASE("aggregate testing", "[aggregates]") {
     status = cylon::compute::Min(table, 1, output);
     REQUIRE(status.is_ok());
 
-    auto array = output->GetColumn(0)->GetColumnData()->chunk(0);
+    auto array = output->get_table()->column(0)->chunk(0);
     auto val = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(array)->Value(0);
 
     REQUIRE(val == 10.0);
@@ -100,7 +100,7 @@ TEST_CASE("aggregate testing", "[aggregates]") {
     status = cylon::compute::Max(table, 1, output);
     REQUIRE(status.is_ok());
 
-    auto array = output->GetColumn(0)->GetColumnData()->chunk(0);
+    auto array = output->get_table()->column(0)->chunk(0);
     auto val = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(array)->Value(0);
 
     REQUIRE(val == 10.0 + (double) (rows - 1));

--- a/cpp/test/create_table_test.cpp
+++ b/cpp/test/create_table_test.cpp
@@ -29,8 +29,7 @@ TEST_CASE("create table from columns testing", "[columns]") {
 
     output->Print();
 
-    std::shared_ptr<arrow::DoubleArray> c =
-        std::static_pointer_cast<arrow::DoubleArray>(output->GetColumn(1)->GetColumnData()->chunk(0));
+    auto c = std::static_pointer_cast<arrow::DoubleArray>(output->get_table()->column(1)->chunk(0));
 
     for (int i = 0; i < c->length(); i++) {
       REQUIRE((c->Value(i) == i + 10.0));

--- a/cpp/test/test_utils.hpp
+++ b/cpp/test/test_utils.hpp
@@ -66,10 +66,10 @@ void TestSetOperation(fun_ptr fn,
 }
 
 void TestJoinOperation(const join::config::JoinConfig &join_config,
-                      const std::shared_ptr<CylonContext> &ctx,
-                      const std::string &path1,
-                      const std::string &path2,
-                      const std::string &out_path) {
+                       const std::shared_ptr<CylonContext> &ctx,
+                       const std::string &path1,
+                       const std::string &path2,
+                       const std::string &out_path) {
   std::shared_ptr<Table> table1, table2, expected, joined, verification;
 
   auto read_options = io::config::CSVReadOptions().UseThreads(false);
@@ -95,26 +95,27 @@ void TestJoinOperation(const join::config::JoinConfig &join_config,
 }
 
 Status CreateTable(const std::shared_ptr<CylonContext> &ctx, int rows, std::shared_ptr<Table> &output) {
-  std::shared_ptr<std::vector<int32_t>> col0 = std::make_shared<std::vector<int32_t >>();
-  std::shared_ptr<std::vector<double_t>> col1 = std::make_shared<std::vector<double_t >>();
+  std::vector<int32_t> col0;
+  std::vector<double_t> col1;
 
   for (int i = 0; i < rows; i++) {
-    col0->push_back(i);
-    col1->push_back((double_t) i + 10.0);
+    col0.push_back(i);
+    col1.push_back((double_t) i + 10.0);
   }
 
-  auto c0 = VectorColumn<int32_t>::Make("col0", Int32(), col0);
-  auto c1 = VectorColumn<double>::Make("col1", Double(), col1);
+  std::shared_ptr<Column> c0, c1;
+  RETURN_CYLON_STATUS_IF_FAILED(Column::FromVector(ctx, "col0", Int32(), col0, c0));
+  RETURN_CYLON_STATUS_IF_FAILED(Column::FromVector(ctx, "col1", Double(), col1, c1));
 
-  return Table::FromColumns(ctx, {c0, c1}, output);
+  return Table::FromColumns(ctx, {std::move(c0), std::move(c1)}, output);
 }
 
 #ifdef BUILD_CYLON_PARQUET
 void TestParquetJoinOperation(const join::config::JoinConfig &join_config,
-                             std::shared_ptr<CylonContext> &ctx,
-                             const std::string &path1,
-                             const std::string &path2,
-                             const std::string &out_path) {
+                              std::shared_ptr<CylonContext> &ctx,
+                              const std::string &path1,
+                              const std::string &path2,
+                              const std::string &out_path) {
   std::shared_ptr<Table> table1, table2, expected, joined, verification;
 
   auto read_options = io::config::ParquetOptions().ConcurrentFileReads(false);

--- a/cpp/test/utils_test.cpp
+++ b/cpp/test/utils_test.cpp
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/test_header.hpp"
+#include "cylon/status.hpp"
+#include "cylon/util/macros.hpp"
+#include "test_arrow_utils.hpp"
+#include "test_macros.hpp"
+
+namespace cylon {
+namespace test {
+
+Status TestUtils() {
+  CYLON_ASSIGN_OR_RAISE(auto a, MakeArrayOfNull(arrow::int32(), 4));
+  REQUIRE(a->length() == 4);
+
+  CYLON_ASSIGN_OR_RAISE(auto b, MakeArrayOfNull(arrow::int32(), 6));
+  REQUIRE(b->length() == 6);
+  return Status::OK();
+}
+
+TEST_CASE("Test Utils"){
+  CHECK_CYLON_STATUS(TestUtils());
+}
+
+} // namespace test
+} // namespace cylon

--- a/python/pycylon/pycylon/data/column.pxd
+++ b/python/pycylon/pycylon/data/column.pxd
@@ -31,31 +31,6 @@ from pyarrow.lib cimport pyarrow_unwrap_array
 
 
 cdef extern from "../../../../cpp/src/cylon/column.hpp" namespace "cylon":
-    cdef cppclass CColumn "cylon::Column":
-        CColumn(const string &id, const shared_ptr[CDataType] &type, const shared_ptr[
-                ArrowCChunkedAarray] &data_)
-
-        CColumn(const string &id, const shared_ptr[CDataType] &type, const shared_ptr[
-                ArrowCAarray] &data_)
-
-        shared_ptr[ArrowCChunkedAarray] GetColumnData() const
-
-        string GetID() const
-
-        shared_ptr[CDataType] GetDataType() const
-
-        @staticmethod
-        shared_ptr[CColumn] Make(const string &id, const shared_ptr[CDataType] &type,
-                                const shared_ptr[ArrowCChunkedAarray] &data_)
-
-        @staticmethod
-        shared_ptr[CColumn] Make(const string &id, const shared_ptr[CDataType] &type,
-                                const shared_ptr[ArrowCAarray] &data_)
-
-
-
-cdef extern from "../../../../cpp/src/cylon/column.hpp" namespace "cylon":
-
     ctypedef fused T:
         signed char
         signed short
@@ -73,17 +48,36 @@ cdef extern from "../../../../cpp/src/cylon/column.hpp" namespace "cylon":
         double
         long double
 
-    cdef cppclass CVectorColumn "cylon::VectorColumn"[T]:
-        CVectorColumn(const string &id, const shared_ptr[CDataType] &type, const shared_ptr[
-                vector[T]] &data_vector)
+    cdef cppclass CColumn "cylon::Column":
+        CColumn(const string & id, const shared_ptr[CDataType] & type, const shared_ptr[
+                ArrowCChunkedAarray] & data_)
 
-        @staticmethod
-        shared_ptr[CVectorColumn[T]] Make(const string &id, const shared_ptr[CDataType] &type,
-                                          const shared_ptr[vector[T]] &data_vector)
+        CColumn(const string & id, const shared_ptr[CDataType] & type, const shared_ptr[
+                ArrowCAarray] & data_)
+
+        shared_ptr[ArrowCChunkedAarray] GetColumnData() const
+
+        string GetID() const
+
+        shared_ptr[CDataType] GetDataType() const
+
+        @ staticmethod
+        shared_ptr[CColumn] Make(const string & id, const shared_ptr[CDataType] & type,
+                                 const shared_ptr[ArrowCChunkedAarray] & data_)
+
+        @ staticmethod
+        shared_ptr[CColumn] Make(const string & id, const shared_ptr[CDataType] & type,
+                                 const shared_ptr[ArrowCAarray] & data_)
+
+        @ staticmethod
+        CStatus FromVector[T](const shared_ptr[CCylonContext] & ctx,
+                              const string & id,
+                              const shared_ptr[CDataType] & type,
+                              const vector[T] & data_vector,
+                              shared_ptr[CColumn] & output)
 
 
 cdef class Column:
     cdef:
         CColumn *thisPtr
         shared_ptr[CColumn] sp_column
-

--- a/python/pycylon/pycylon/data/column.pyx
+++ b/python/pycylon/pycylon/data/column.pyx
@@ -31,7 +31,6 @@ from pyarrow.lib cimport CArray as ArrowCAarray
 from pyarrow.lib cimport CChunkedArray as ArrowCChunkedAarray
 from pyarrow.lib cimport pyarrow_unwrap_array
 from pycylon.data.column cimport CColumn
-from pycylon.data.column cimport CVectorColumn
 from pycylon.api.lib cimport pycylon_unwrap_data_type, pycylon_wrap_data_type
 from pycylon.data.data_type import DataType
 from pyarrow.lib cimport pyarrow_unwrap_array, pyarrow_wrap_array
@@ -60,10 +59,4 @@ cdef class Column:
         cdef shared_ptr[CDataType] cdtype = self.thisPtr.GetDataType()
         return pycylon_wrap_data_type(cdtype)
 
-
-cdef class VectorColumn:
-
-    def __cinit__(self, id, type, data_list):
-        # TODO: Implement if required
-       pass
 


### PR DESCRIPTION
This PR 
- removes the dangling `vector<shared_ptr<Column>> columns` parameter from the `Table`
- removes `VectorColumn` class as it hardly serves any purpose 
- fixes  CYLON_ASSIGN_OR_RAISE multiple invocation issue 