### PR TITLE
added mpi datatype dispatching for primitive data types

### DIFF
--- a/cpp/src/cylon/CMakeLists.txt
+++ b/cpp/src/cylon/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(cylon SHARED
         net/mpi/mpi_communicator.hpp
         net/mpi/mpi_operations.cpp
         net/mpi/mpi_operations.hpp
+        net/mpi/mpi_type_traits.hpp
         net/ops/all_to_all.cpp
         net/ops/all_to_all.hpp
         net/ops/gather.cpp

--- a/cpp/src/cylon/net/comm_operations.hpp
+++ b/cpp/src/cylon/net/comm_operations.hpp
@@ -27,7 +27,12 @@ namespace net {
 enum ReduceOp {
   SUM,
   MIN,
-  MAX
+  MAX,
+  PROD,
+  LAND,
+  LOR,
+  BAND,
+  BOR,
 };
 
 }

--- a/cpp/src/cylon/net/mpi/mpi_communicator.cpp
+++ b/cpp/src/cylon/net/mpi/mpi_communicator.cpp
@@ -18,7 +18,7 @@
 #include <cylon/net/communicator.hpp>
 #include <cylon/net/mpi/mpi_communicator.hpp>
 #include <cylon/net/mpi/mpi_channel.hpp>
-#include <cylon/net/mpi/mpi_operations.hpp>
+#include <cylon/util/macros.hpp>
 
 namespace cylon {
 namespace net {
@@ -50,6 +50,7 @@ int MPICommunicator::GetWorldSize() const {
   return this->world_size;
 }
 Status MPICommunicator::Init(const std::shared_ptr<CommConfig> &config) {
+  CYLON_UNUSED(config);
   int initialized;
   MPI_Initialized(&initialized);
   if (!initialized) {

--- a/cpp/src/cylon/net/mpi/mpi_operations.cpp
+++ b/cpp/src/cylon/net/mpi/mpi_operations.cpp
@@ -17,10 +17,14 @@
 
 MPI_Op cylon::mpi::GetMPIOp(cylon::net::ReduceOp reduce_op) {
   switch (reduce_op) {
-    case cylon::net::SUM: return MPI_SUM;
-    case cylon::net::MIN: return MPI_MIN;
-    case cylon::net::MAX: return MPI_MAX;
-//    case cylon::PROD: return MPI_PROD;
+    case net::SUM: return MPI_SUM;
+    case net::MIN: return MPI_MIN;
+    case net::MAX: return MPI_MAX;
+    case net::PROD: return MPI_PROD;
+    case net::LAND:return MPI_LAND;
+    case net::LOR:return MPI_LOR;
+    case net::BAND:return MPI_BAND;
+    case net::BOR:return MPI_BOR;
     default: return MPI_OP_NULL;
   }
 }

--- a/cpp/src/cylon/net/mpi/mpi_type_traits.hpp
+++ b/cpp/src/cylon/net/mpi/mpi_type_traits.hpp
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef CYLON_CPP_SRC_CYLON_NET_MPI_MPI_TYPE_TRAITS_HPP_
+#define CYLON_CPP_SRC_CYLON_NET_MPI_MPI_TYPE_TRAITS_HPP_
+
+#include <mpi.h>
+
+namespace cylon {
+
+template<typename T>
+struct MPICTypeTraits {};
+
+template<>
+struct MPICTypeTraits<uint8_t> {
+  static MPI_Datatype MPIDataType() { return MPI_UINT8_T; }
+};
+
+template<>
+struct MPICTypeTraits<int8_t> {
+  static MPI_Datatype MPIDataType() { return MPI_INT8_T; }
+};
+
+template<>
+struct MPICTypeTraits<uint16_t> {
+  static MPI_Datatype MPIDataType() { return MPI_UINT16_T; }
+};
+
+template<>
+struct MPICTypeTraits<int16_t> {
+  static MPI_Datatype MPIDataType() { return MPI_INT16_T; }
+};
+
+template<>
+struct MPICTypeTraits<uint32_t> {
+  static MPI_Datatype MPIDataType() { return MPI_UINT32_T; }
+};
+
+template<>
+struct MPICTypeTraits<int32_t> {
+  static MPI_Datatype MPIDataType() { return MPI_INT32_T; }
+};
+
+template<>
+struct MPICTypeTraits<uint64_t> {
+  static MPI_Datatype MPIDataType() { return MPI_UINT64_T; }
+};
+
+template<>
+struct MPICTypeTraits<int64_t> {
+  static MPI_Datatype MPIDataType() { return MPI_INT64_T; }
+};
+
+template<>
+struct MPICTypeTraits<float> {
+  static MPI_Datatype MPIDataType() { return MPI_FLOAT; }
+};
+
+template<>
+struct MPICTypeTraits<double> {
+  static MPI_Datatype MPIDataType() { return MPI_DOUBLE; }
+};
+
+}
+
+#endif //CYLON_CPP_SRC_CYLON_NET_MPI_MPI_TYPE_TRAITS_HPP_

--- a/cpp/src/cylon/net/ops/gather.cpp
+++ b/cpp/src/cylon/net/ops/gather.cpp
@@ -153,24 +153,5 @@ cylon::Status cylon::mpi::Gather(const std::shared_ptr<cylon::TableSerializer> &
   return cylon::Status::OK();
 }
 
-cylon::Status cylon::mpi::AllGather(const std::vector<int32_t> &send_data,
-                                    int number_of_workers,
-                                    std::vector<int32_t> &received_data) {
-
-    received_data.resize(number_of_workers * send_data.size());
-
-    auto status = MPI_Allgather(send_data.data(),
-                                send_data.size(),
-                                MPI_INT32_T,
-                                received_data.data(),
-                                send_data.size(),
-                                MPI_INT32_T,
-                                MPI_COMM_WORLD);
-    if (status != MPI_SUCCESS) {
-        return cylon::Status(cylon::Code::ExecutionError, "MPI_Allgather failed!");
-    }
-
-    return cylon::Status::OK();
-}
 
 


### PR DESCRIPTION
I added MPI DataType dispaching for primitive data types.
I made MPI AllGather more general with vector<T> as input and output type. 