### PR TITLE
Make contributing to docs easier

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -74,13 +74,15 @@ module.exports = {
                     // It is recommended to set document id as docs home page (`docs/` path).
                     homePageId: 'compile',
                     sidebarPath: require.resolve('./sidebars.js'),
-                    editUrl:
-                        'https://github.com/cylondata/cylon/edit/master/docs/',
+                    editUrl: ({ docPath }) => {
+                        return `https://holocron.so/github/pr/cylondata/cylon/main/editor/docs/docs/${docPath}`
+                    },
                 },
                 blog: {
                     showReadingTime: true,
-                    editUrl:
-                        'https://github.com/cylondata/cylon/edit/master/blog/',
+                    editUrl: ({ docPath }) => {
+                        return `https://holocron.so/github/pr/cylondata/cylon/main/editor/docs/blog/${docPath}`
+                    },
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/cylondata/cylon/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb